### PR TITLE
fix: Type `navLinks` as NavLink array to resolve `TypeScript never[]`

### DIFF
--- a/src/lib/site.ts
+++ b/src/lib/site.ts
@@ -1,5 +1,5 @@
 // Navigation links for the website
-export const navLinks = [
+export const navLinks: { href: string; label: string }[] = [
 ];
 
 // Profile information


### PR DESCRIPTION
**Description:**
`navLinks` in `site.ts` was declared as an empty array without a type annotation, causing TypeScript to infer it as `never[]`. This caused a type error in `NavPanel.tsx` when accessing `link.href`.

**Changes:**
- Added explicit `{ href: string; label: string }[]` type to `navLinks` in `src/lib/site.ts`

**Root Cause:**
TypeScript infers an untyped empty array as `never[]`, meaning it assumes the array can never contain items, so any property access on its elements fails at compile time.