### PR TITLE
fix: Smoothen collapse animation for project accordion tags

### DIFF
--- a/src/components/ui/Accordion.tsx
+++ b/src/components/ui/Accordion.tsx
@@ -31,7 +31,7 @@ export default function AccordionItem({
   leftAdornment,
   preview,
 }: Props) {
-  const { contentRef, animate } = useAccordion();
+  const { contentRef, previewRef, animate } = useAccordion();
 
   useEffect(() => {
     animate(isOpen);
@@ -85,7 +85,7 @@ export default function AccordionItem({
 
       {/* Preview Content below Subtitle */}
       {preview && (
-        <div className="-ml-0.5 pt-1 max-w-100 sm:max-w-[calc(100%-8rem)]">{preview}</div>
+        <div ref={previewRef} className="-ml-0.5 pt-1 max-w-100 sm:max-w-[calc(100%-8rem)]">{preview}</div>
       )}
       
       {/* Bullet Lines */}

--- a/src/hooks/animations/useAccordion.ts
+++ b/src/hooks/animations/useAccordion.ts
@@ -5,16 +5,24 @@ import { gsap } from "gsap";
 
 type UseAccordionResult = {
   contentRef: React.RefObject<HTMLUListElement | null>;
+  previewRef: React.RefObject<HTMLDivElement | null>;
   animate: (isOpen: boolean) => void;
 };
 
 export function useAccordion(): UseAccordionResult {
   const contentRef = useRef<HTMLUListElement | null>(null);
+  const previewRef = useRef<HTMLDivElement | null>(null);
+  const naturalPreviewHeight = useRef<number>(0);
 
   useEffect(() => {
     if (contentRef.current) {
       contentRef.current.classList.remove("invisible");
       gsap.set(contentRef.current, { opacity: 0, height: 0, overflow: "hidden", marginTop: 0 });
+    }
+    
+    if (previewRef.current) {
+      naturalPreviewHeight.current = previewRef.current.scrollHeight;
+      gsap.set(previewRef.current, { overflow: "hidden", height: "auto" });
     }
   }, []);
 
@@ -23,15 +31,29 @@ export function useAccordion(): UseAccordionResult {
 
     if (isOpen) {
       const height = contentRef.current.scrollHeight;
+
       gsap.to(contentRef.current, {
         height, opacity: 1, marginTop: 16, duration: 0.3, ease: "power2.out"
       });
+
+      if (previewRef.current) {
+        gsap.to(previewRef.current, { height: "auto", duration: 0.3, ease: "power2.out" });
+      }
     } else {
       gsap.to(contentRef.current, {
         height: 0, opacity: 0, marginTop: 0, duration: 0.2, ease: "power2.in"
       });
+
+      if (previewRef.current) {
+        gsap.to(previewRef.current, {
+          height: naturalPreviewHeight.current,
+          duration: 0.2,
+          ease: "power2.in",
+          overwrite: true,
+        });
+      }
     }
   }, []);
 
-  return { contentRef, animate };
+  return { contentRef, previewRef, animate };
 }


### PR DESCRIPTION
Closes #28

## What changed
- Captured the natural height of `previewRef` on mount via a ref (`naturalPreviewHeight`) instead of reading `scrollHeight` mid-animation
- Used `naturalPreviewHeight` in the close animation to correctly collapse to the visible tags' height
- Removed brittle tag height calculations that were causing clipping on smaller screens