### PR TITLE
fix: Accordion spam protection and tag counter flicker on mount

### DIFF
--- a/src/components/ui/Accordion.tsx
+++ b/src/components/ui/Accordion.tsx
@@ -31,14 +31,10 @@ export default function AccordionItem({
   leftAdornment,
   preview,
 }: Props) {
-  const { contentRef, previewRef, animate } = useAccordion();
-
-  useEffect(() => {
-    animate(isOpen);
-  }, [isOpen, animate]);
+  const { contentRef, previewRef, animate, isAnimating } = useAccordion();
 
   const handleToggle = () => {
-    if (disabled) return;
+    if (disabled || isAnimating.current) return;
     animate(!isOpen);
     onToggle();
   };

--- a/src/hooks/animations/useAccordion.ts
+++ b/src/hooks/animations/useAccordion.ts
@@ -7,9 +7,11 @@ type UseAccordionResult = {
   contentRef: React.RefObject<HTMLUListElement | null>;
   previewRef: React.RefObject<HTMLDivElement | null>;
   animate: (isOpen: boolean) => void;
+  isAnimating: React.RefObject<boolean>;
 };
 
 export function useAccordion(): UseAccordionResult {
+  const isAnimating = useRef(false);
   const contentRef = useRef<HTMLUListElement | null>(null);
   const previewRef = useRef<HTMLDivElement | null>(null);
   const naturalPreviewHeight = useRef<number>(0);
@@ -28,12 +30,14 @@ export function useAccordion(): UseAccordionResult {
 
   const animate = useCallback((isOpen: boolean) => {
     if (!contentRef.current) return;
+    isAnimating.current = true;
 
     if (isOpen) {
       const height = contentRef.current.scrollHeight;
 
       gsap.to(contentRef.current, {
-        height, opacity: 1, marginTop: 16, duration: 0.3, ease: "power2.out"
+        height, opacity: 1, marginTop: 16, duration: 0.3, ease: "power2.out",
+        onComplete: () => { isAnimating.current = false; }
       });
 
       if (previewRef.current) {
@@ -41,7 +45,8 @@ export function useAccordion(): UseAccordionResult {
       }
     } else {
       gsap.to(contentRef.current, {
-        height: 0, opacity: 0, marginTop: 0, duration: 0.2, ease: "power2.in"
+        height: 0, opacity: 0, marginTop: 0, duration: 0.2, ease: "power2.in",
+        onComplete: () => { isAnimating.current = false; }
       });
 
       if (previewRef.current) {
@@ -55,5 +60,5 @@ export function useAccordion(): UseAccordionResult {
     }
   }, []);
 
-  return { contentRef, previewRef, animate };
+  return { contentRef, previewRef, animate, isAnimating };
 }

--- a/src/hooks/animations/useExpandTags.ts
+++ b/src/hooks/animations/useExpandTags.ts
@@ -1,10 +1,11 @@
-import { useEffect, RefObject } from "react";
+import { useEffect, RefObject, useRef } from "react";
 import gsap from "gsap";
 
 export function useExpandTags(
   containerRef: RefObject<HTMLDivElement | null>,
   isExpanded: boolean,
 ) {
+  const isMounted = useRef(false);
   useEffect(() => {
     const container = containerRef.current;
     if (!container) return;
@@ -12,6 +13,11 @@ export function useExpandTags(
     const hiddenTags = container.querySelectorAll(".animate-tag");
     const counter = container.querySelector(".tag-counter");
     if (hiddenTags.length === 0) return;
+
+    if (!isMounted.current) {
+      isMounted.current = true;
+      return;
+    }
 
     if (isExpanded) {
       // Hide counter immediately before tags animate in


### PR DESCRIPTION
## What changed

### Spam protection
- Locked toggle during animation via `isAnimating` ref in `useAccordion`
- Guard check in `handleToggle` in `Accordion.tsx` prevents firing while animation is in progress

### Tag counter flicker
- Set initial `opacity` of `+N` counter based on `isExpanded` in `ProjectTags` to prevent flash before JS hydrates
- Added `isMounted` ref in `useExpandTags` to skip GSAP on first mount, preventing it from overriding the initial opacity