### PR TITLE
feat: Add post-drag pause and fixes for TechStack marquee and GitHub avatar

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,7 +14,8 @@
 # Next.js
 /.next/
 /out/
-src/app/icon.png
+/public/avatar.png
+/src/app/icon.png
 
 # Production
 /build

--- a/scripts/generate-favicon.ts
+++ b/scripts/generate-favicon.ts
@@ -1,10 +1,13 @@
-import { writeFileSync } from "fs";
-import { profileInfo } from "../src/lib/site";
+import { writeFileSync, mkdirSync } from "fs";
+import { socialLinks } from "../src/lib/site";
 
 async function main() {
-  const res = await fetch(profileInfo.image);
+  const github = socialLinks.find((s) => s.label === "GitHub")!;
+  const res = await fetch(`${github.link}.png`);
   const buffer = await res.arrayBuffer();
+  mkdirSync("public", { recursive: true });
   writeFileSync("src/app/icon.png", Buffer.from(buffer));
+  writeFileSync("public/avatar.png", Buffer.from(buffer));
   console.log("✔ favicon fetched");
 }
 

--- a/src/components/sections/TechStack.tsx
+++ b/src/components/sections/TechStack.tsx
@@ -122,7 +122,7 @@ export default function TechStack() {
 
       <div
         ref={wrapperRef}
-        className="relative max-w-210 mx-auto w-full overflow-hidden cursor-grab active:cursor-grabbing px-6"
+        className="relative max-w-210 mx-auto w-full overflow-hidden px-6"
         style={{
           maskImage: "linear-gradient(to right, transparent, black 20%, black 80%, transparent)",
           WebkitMaskImage: "linear-gradient(to right, transparent, black 20%, black 80%, transparent)",

--- a/src/hooks/animations/useTechMarquee.ts
+++ b/src/hooks/animations/useTechMarquee.ts
@@ -5,6 +5,7 @@ const CONFIG = {
   duration: 30,      // auto-scroll speed (higher = slower)
   momentum: 24,      // swipe momentum multiplier
   glide: 2,          // how long it coasts back to normal speed (seconds)
+  pause: 1.5,        // seconds to pause before resuming auto-scroll
 };
 
 export function useTechMarquee() {
@@ -69,6 +70,7 @@ export function useTechMarquee() {
     const endDrag = () => {
       if (!isDragging.current) return;
       isDragging.current = false;
+      gsap.killTweensOf(tween);
 
       const samples = velocitySamples.current;
       const avgVelocity = samples.length
@@ -76,8 +78,8 @@ export function useTechMarquee() {
         : 0;
 
       // Don't apply inertia if barely moving
-      if (Math.abs(avgVelocity) < 1) {
-        tween.timeScale(1);
+      if (Math.abs(avgVelocity) < 0.7) {
+        gsap.delayedCall(CONFIG.pause, () => gsap.to(tween, { timeScale: 1, duration: CONFIG.glide, ease: "power3.out" }));
         return;
       }
 

--- a/src/hooks/animations/useTechMarquee.ts
+++ b/src/hooks/animations/useTechMarquee.ts
@@ -10,6 +10,7 @@ const CONFIG = {
 
 export function useTechMarquee() {
   const wrapperRef = useRef<HTMLDivElement>(null);
+  const pauseTimer = useRef<gsap.core.Tween | null>(null);
 
   useEffect(() => {
     const wrapper = wrapperRef.current;
@@ -40,6 +41,7 @@ export function useTechMarquee() {
       lastTimestamp.current = performance.now();
       velocitySamples.current = [];
       gsap.killTweensOf(tween);
+      pauseTimer.current?.kill();
       tween.timeScale(0);
     };
 
@@ -79,7 +81,7 @@ export function useTechMarquee() {
 
       // Don't apply inertia if barely moving
       if (Math.abs(avgVelocity) < 0.7) {
-        gsap.delayedCall(CONFIG.pause, () => gsap.to(tween, { timeScale: 1, duration: CONFIG.glide, ease: "power3.out" }));
+        pauseTimer.current = gsap.delayedCall(CONFIG.pause, () => gsap.to(tween, { timeScale: 1, duration: CONFIG.glide, ease: "power3.out" }));
         return;
       }
 

--- a/src/lib/site.ts
+++ b/src/lib/site.ts
@@ -8,7 +8,7 @@ export const profileInfo = {
   title: "DevOps Engineer / Full-Stack Developer",
   location: "Pasig City, Philippines",
   bio: "DevOps Engineer with full-stack experience. I build, deploy, and maintain scalable systems end to end.",
-  image: "https://github.com/cymophic.png",
+  image: "/avatar.png",
 }
 
 // Social media links


### PR DESCRIPTION
## What's Changed
- Add configurable pause before `TechStack` marquee resumes auto-scroll after drag
- Fix pause timer not resetting on new drag interaction in `TechStack`
- Fix fetched GitHub avatar not writing to `public/` for same-origin access