### PR TITLE
feat: Polish Intro with new AnimatedText component, scramble variant, polish Intro, and header fixes

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -4,6 +4,8 @@ import { GoogleAnalytics } from "@next/third-parties/google";
 import Nav from "@/components/layout/header/Header";
 import ThemeProvider from "@/components/layout/theme/ThemeProvider";
 import ComingSoon from "@/components/pages/ComingSoon";
+import { profileInfo } from "@/lib/site";
+
 const SITE_MODE = process.env.NEXT_PUBLIC_SITE_MODE;
 import "./globals.css";
 
@@ -20,7 +22,7 @@ const geistMono = Geist_Mono({
 });
 
 export const metadata: Metadata = {
-  title: "Luis Abhram | DevOps Engineer",
+  title: `${profileInfo.name} | ${profileInfo.title}`,
   description: "Personal portfolio of Luis Abhram Mata",
 };
 

--- a/src/components/layout/footer/Footer.tsx
+++ b/src/components/layout/footer/Footer.tsx
@@ -18,7 +18,7 @@ export default function Footer() {
 
       {/* Footer Image */}
       <button onClick={() => window.scrollTo({ top: 0, behavior: "smooth" })}>
-        <ProfileImage width={64} height={64} />
+        <ProfileImage width={48} height={48} />
       </button>
 
       {/* Social Links */}

--- a/src/components/layout/footer/Footer.tsx
+++ b/src/components/layout/footer/Footer.tsx
@@ -7,19 +7,19 @@ import SocialLinks from "../../sections/common/SocialLinks";
 
 export default function Footer() {
   return (
-    <footer className="flex flex-col items-center text-center gap-8">
+    <footer className="flex flex-col items-center text-center gap-6">
       {/* Line */}
       <div className="w-px h-16 bg-zinc-300 dark:bg-zinc-700"/>
-
-      {/* Footer Image */}
-      <button onClick={() => window.scrollTo({ top: 0, behavior: "smooth" })}>
-        <ProfileImage width={64} height={64} />
-      </button>
 
       {/* Byline */}
       <p className="font-mono text-xs tracking-wider uppercase font-semibold text-zinc-400 dark:text-zinc-500">
         Made with <FiHeart className="inline" style={{ strokeWidth: 3 }} /> by {profileInfo.name}
       </p>
+
+      {/* Footer Image */}
+      <button onClick={() => window.scrollTo({ top: 0, behavior: "smooth" })}>
+        <ProfileImage width={64} height={64} />
+      </button>
 
       {/* Social Links */}
       <SocialLinks opacity={50} iconSize={16} />

--- a/src/components/layout/header/Header.tsx
+++ b/src/components/layout/header/Header.tsx
@@ -12,7 +12,7 @@ import ThemeToggle from "@/components/layout/theme/ThemeToggle";
 export default function Nav() {
   const { open, visible, toggle, close, panelRef, linksRef, iconsRef } = useToggleSidebar();
   const showNavToggle = navLinks.length > 0;
-  const headerRef = useHideOnScroll();
+  const { ref: headerRef, isHidden } = useHideOnScroll();
 
   const handleToggle = (event: MouseEvent<HTMLButtonElement>) => {
     event.stopPropagation();
@@ -21,7 +21,7 @@ export default function Nav() {
 
   return (
     <>
-      <header ref={headerRef} className="fixed top-0 left-0 right-0 z-50 flex items-center justify-between px-4 py-4 pointer-events-none">
+      <header ref={headerRef} className={`fixed top-0 left-0 right-0 z-50 flex items-center justify-between px-4 py-4 pointer-events-none ${isHidden ? "overflow-hidden" : ""}`}>
         {/* Sidebar Toggle Button */}
         <div className="pointer-events-auto -ml-1">
           {showNavToggle && <SidebarToggle open={open} onToggle={handleToggle} />}
@@ -32,9 +32,10 @@ export default function Nav() {
           <ThemeToggle />
         </div>
 
-       <div className="absolute inset-0 -z-10 bg-linear-to-b from-zinc-50 via-zinc-50/60 dark:from-zinc-950 dark:via-zinc-950/60 to-transparent pointer-events-none h-36"/>
+        {/* Header Background */}
+        <div className="absolute inset-0 -z-10 bg-linear-to-b from-zinc-50 via-zinc-50/60 dark:from-zinc-950 dark:via-zinc-950/60 to-transparent pointer-events-none h-36"/>
       </header>
-      
+
       {/* Sidebar Panel */}
       {showNavToggle && (
         <>
@@ -59,4 +60,3 @@ export default function Nav() {
     </>
   );
 }
-

--- a/src/components/layout/header/Header.tsx
+++ b/src/components/layout/header/Header.tsx
@@ -33,7 +33,7 @@ export default function Nav() {
         </div>
 
         {/* Header Background */}
-        <div className="absolute inset-0 -z-10 bg-linear-to-b from-zinc-50 via-zinc-50/60 dark:from-zinc-950 dark:via-zinc-950/60 to-transparent pointer-events-none h-36"/>
+        <div className="absolute inset-0 -z-10 bg-linear-to-b from-zinc-50 via-zinc-50/60 dark:from-zinc-950 dark:via-zinc-950/60 to-transparent pointer-events-none h-36 xl:hidden"/>
       </header>
 
       {/* Sidebar Panel */}

--- a/src/components/sections/Intro.tsx
+++ b/src/components/sections/Intro.tsx
@@ -1,31 +1,42 @@
-import { profileInfo } from "@/lib/site";
+"use client";
+
+import { useState } from "react";
+import { profileInfo, greetingMessages } from "@/lib/site";
 import SocialLinks from "@/components/sections/common/SocialLinks";
 import ProfileImage from "@/components/sections/common/ProfileImage";
 
 export default function Intro() {
+  const [greeting] = useState(
+    () => greetingMessages[Math.floor(Math.random() * greetingMessages.length)]
+  );
+
   return (
     <section className="w-full">
       <div className="flex flex-col mx-auto max-w-4xl mt-24 px-6 sm:flex-row sm:justify-between sm:gap-12 sm:items-center sm:px-10">
         <div className="flex flex-col gap-4 sm:gap-6">
-          {/* Text Content */}
           <div className="flex flex-row justify-between gap-x-8">
             <div>
-              <p className="max-w-md text-sm sm:text-base text-zinc-600 dark:text-zinc-400">
-                {`Hi! I am`}
+              {/* Greeting */}
+              <p className="font-consolas max-w-md text-sm sm:text-base text-zinc-600 dark:text-zinc-400" suppressHydrationWarning>
+                {greeting}
               </p>
+              {/* Name */}
               <h1 className="text-4xl sm:text-5xl font-semibold leading-tight tracking-tight text-zinc-700 dark:text-zinc-50">
                 {profileInfo.name}
               </h1>
             </div>
+
             {/* Profile Image - Small Screens */}
             <div className="shrink-0 sm:hidden -ml-1">
               <ProfileImage width={64} height={64} />
             </div>
           </div>
+
+          {/* Bio */}
           <p className="max-w-md text-sm sm:text-base text-zinc-600 dark:text-zinc-400">
             {profileInfo.bio}
           </p>
-          
+
           {/* Social Links */}
           <div className="mt-2">
             <SocialLinks />
@@ -40,4 +51,3 @@ export default function Intro() {
     </section>
   );
 }
-

--- a/src/components/sections/Intro.tsx
+++ b/src/components/sections/Intro.tsx
@@ -34,7 +34,7 @@ export default function Intro() {
 
         {/* Profile Image - Large Screens */}
         <div className="shrink-0 hidden sm:block">
-          <ProfileImage width={160} height={160} />
+          <ProfileImage width={180} height={180} />
         </div>
       </div>
     </section>

--- a/src/components/sections/Intro.tsx
+++ b/src/components/sections/Intro.tsx
@@ -1,14 +1,18 @@
 "use client";
 
-import { useState } from "react";
+import { useState } from "react"
 import { profileInfo, greetingMessages } from "@/lib/site";
+import { useTypingAnimation } from "@/hooks/animations/useTypingAnimation";
 import SocialLinks from "@/components/sections/common/SocialLinks";
 import ProfileImage from "@/components/sections/common/ProfileImage";
+import TypingText from "@/components/ui/TypingText";
+
+const CONFIG = {
+  greetingInterval: 3700, // how long each greeting stays before swapping
+};
 
 export default function Intro() {
-  const [greeting] = useState(
-    () => greetingMessages[Math.floor(Math.random() * greetingMessages.length)]
-  );
+  const [shuffled] = useState(() => [...greetingMessages].sort(() => Math.random() - 0.5));
 
   return (
     <section className="w-full">
@@ -18,7 +22,13 @@ export default function Intro() {
             <div>
               {/* Greeting */}
               <p className="font-consolas max-w-md text-sm sm:text-base text-zinc-600 dark:text-zinc-400" suppressHydrationWarning>
-                {greeting}
+                <TypingText
+                  words={shuffled}
+                  className="font-consolas max-w-md text-sm sm:text-base text-zinc-600 dark:text-zinc-400"
+                  config={{
+                    pauseMs: CONFIG.greetingInterval,
+                  }}
+                />
               </p>
               {/* Name */}
               <h1 className="text-4xl sm:text-5xl font-semibold leading-tight tracking-tight text-zinc-700 dark:text-zinc-50">

--- a/src/components/sections/Intro.tsx
+++ b/src/components/sections/Intro.tsx
@@ -1,38 +1,32 @@
 "use client";
 
-import { useState } from "react"
-import { profileInfo, greetingMessages } from "@/lib/site";
-import { useTypingAnimation } from "@/hooks/animations/useTypingAnimation";
+import { profileInfo } from "@/lib/site";
 import SocialLinks from "@/components/sections/common/SocialLinks";
 import ProfileImage from "@/components/sections/common/ProfileImage";
 import TypingText from "@/components/ui/TypingText";
 
 const CONFIG = {
-  greetingInterval: 3700, // how long each greeting stays before swapping
+  wordsInterval: 3700, // how long each greeting stays before swapping
+  deletingSpeed: 20, // time it takes to delete the word
 };
 
 export default function Intro() {
-  const [shuffled] = useState(() => [...greetingMessages].sort(() => Math.random() - 0.5));
-
   return (
     <section className="w-full">
       <div className="flex flex-col mx-auto max-w-4xl mt-24 px-6 sm:flex-row sm:justify-between sm:gap-12 sm:items-center sm:px-10">
         <div className="flex flex-col gap-4 sm:gap-6">
           <div className="flex flex-row justify-between gap-x-8">
             <div>
-              {/* Greeting */}
-              <p className="font-consolas max-w-md text-sm sm:text-base text-zinc-600 dark:text-zinc-400" suppressHydrationWarning>
+              {/* Name */}
+              <h1>
                 <TypingText
-                  words={shuffled}
-                  className="font-consolas max-w-md text-sm sm:text-base text-zinc-600 dark:text-zinc-400"
+                  words={["Luis Abhram"]}
+                  className="font-mono text-5xl font-semibold leading-tight tracking-wide text-zinc-700 dark:text-zinc-50"
                   config={{
-                    pauseMs: CONFIG.greetingInterval,
+                    pauseMs: CONFIG.wordsInterval,
+                    deletingSpeedMs: CONFIG.deletingSpeed,
                   }}
                 />
-              </p>
-              {/* Name */}
-              <h1 className="text-4xl sm:text-5xl font-semibold leading-tight tracking-tight text-zinc-700 dark:text-zinc-50">
-                {profileInfo.name}
               </h1>
             </div>
 

--- a/src/components/sections/Intro.tsx
+++ b/src/components/sections/Intro.tsx
@@ -5,17 +5,23 @@ import ProfileImage from "@/components/sections/common/ProfileImage";
 export default function Intro() {
   return (
     <section className="w-full">
-      <div className="mx-auto mt-24 flex max-w-4xl flex-col md:flex-row md:items-center md:justify-between md:gap-12 px-6 sm:px-10">
-        <div className="flex flex-col gap-4 md:gap-6">
-          {/* Profile Image - Small Screens */}
-          <div className="shrink-0 md:hidden -ml-1">
-            <ProfileImage width={64} height={64} />
-          </div>
-
+      <div className="flex flex-col mx-auto max-w-4xl mt-24 px-6 sm:flex-row sm:justify-between sm:gap-12 sm:items-center sm:px-10">
+        <div className="flex flex-col gap-4 sm:gap-6">
           {/* Text Content */}
-          <h1 className="text-3xl sm:text-4xl md:text-5xl font-semibold leading-tight tracking-tight text-zinc-700 dark:text-zinc-50">
-            {profileInfo.name}
-          </h1>
+          <div className="flex flex-row justify-between gap-x-8">
+            <div>
+              <p className="max-w-md text-sm sm:text-base text-zinc-600 dark:text-zinc-400">
+                {`Hi! I am`}
+              </p>
+              <h1 className="text-4xl sm:text-5xl font-semibold leading-tight tracking-tight text-zinc-700 dark:text-zinc-50">
+                {profileInfo.name}
+              </h1>
+            </div>
+            {/* Profile Image - Small Screens */}
+            <div className="shrink-0 sm:hidden -ml-1">
+              <ProfileImage width={64} height={64} />
+            </div>
+          </div>
           <p className="max-w-md text-sm sm:text-base text-zinc-600 dark:text-zinc-400">
             {profileInfo.bio}
           </p>
@@ -27,7 +33,7 @@ export default function Intro() {
         </div>
 
         {/* Profile Image - Large Screens */}
-        <div className="shrink-0 hidden md:block">
+        <div className="shrink-0 hidden sm:block">
           <ProfileImage width={160} height={160} />
         </div>
       </div>

--- a/src/components/sections/Intro.tsx
+++ b/src/components/sections/Intro.tsx
@@ -3,7 +3,7 @@
 import { profileInfo } from "@/lib/site";
 import SocialLinks from "@/components/sections/common/SocialLinks";
 import ProfileImage from "@/components/sections/common/ProfileImage";
-import TypingText from "@/components/ui/TypingText";
+import AnimateText from "@/components/ui/AnimatedText";
 
 const CONFIG = {
   wordsInterval: 3700, // how long each greeting stays before swapping
@@ -15,26 +15,24 @@ export default function Intro() {
     <section className="w-full">
       <div className="flex flex-col mx-auto max-w-4xl mt-24 px-6 sm:flex-row sm:justify-between sm:gap-12 sm:items-center sm:px-10">
         <div className="flex flex-col gap-4 sm:gap-6">
-          <div className="flex flex-row justify-between gap-x-8">
-            <div>
-              {/* Name */}
-              <h1>
-                <TypingText
-                  words={["Luis Abhram"]}
-                  className="font-mono text-5xl font-semibold leading-tight tracking-wide text-zinc-700 dark:text-zinc-50"
-                  config={{
-                    pauseMs: CONFIG.wordsInterval,
-                    deletingSpeedMs: CONFIG.deletingSpeed,
-                  }}
-                />
-              </h1>
-            </div>
-
-            {/* Profile Image - Small Screens */}
-            <div className="shrink-0 sm:hidden -ml-1">
-              <ProfileImage width={64} height={64} />
-            </div>
+          {/* Profile Image - Small Screens */}
+          <div className="shrink-0 sm:hidden ">
+            <ProfileImage width={64} height={64} />
           </div>
+
+          {/* Name */}
+          <h1>
+            <AnimateText
+              words={["Luis Abhram"]}
+              className="font-mono text-3xl sm:text-5xl font-semibold leading-tight tracking-wide text-zinc-700 dark:text-zinc-50"
+              variant="scramble"
+              cursor="underscore"
+              config={{
+                pauseMs: CONFIG.wordsInterval,
+                deletingSpeedMs: CONFIG.deletingSpeed,
+              }}
+            />
+          </h1>
 
           {/* Bio */}
           <p className="max-w-md text-sm sm:text-base text-zinc-600 dark:text-zinc-400">
@@ -49,7 +47,7 @@ export default function Intro() {
 
         {/* Profile Image - Large Screens */}
         <div className="shrink-0 hidden sm:block">
-          <ProfileImage width={180} height={180} />
+          <ProfileImage width={160} height={160} />
         </div>
       </div>
     </section>

--- a/src/components/sections/TechStack.tsx
+++ b/src/components/sections/TechStack.tsx
@@ -128,7 +128,7 @@ export default function TechStack() {
           WebkitMaskImage: "linear-gradient(to right, transparent, black 20%, black 80%, transparent)",
         }}
       >
-        <div className="marquee-track flex w-max gap-3 py-10">
+        <div className="marquee-track flex w-max gap-3 py-10 active:cursor-pointer">
           {[...allTechs, ...allTechs].map((tech, i) => (
             <TechItem key={`${tech}-${i}`} label={tech} />
           ))}

--- a/src/components/ui/AnimatedText.tsx
+++ b/src/components/ui/AnimatedText.tsx
@@ -3,28 +3,44 @@
 import { useEffect, useRef } from "react";
 import gsap from "gsap";
 import { useTypingAnimation } from "@/hooks/animations/useTypingAnimation";
+import { useScramble } from "@/hooks/animations/useScrambleText";
 
-interface TypingTextProps {
+interface AnimatedTextProps {
   words: string[];
+  variant?: "typing" | "scramble";
   className?: string;
   cursor?: "block" | "underscore" | "bar" | "none";
   config?: {
     pauseMs?: number;
     typingSpeedMs?: number;
     deletingSpeedMs?: number;
+    scrambleDurationMs?: number;
+    scrambleIntervalMs?: number;
   };
 }
 
 const CURSORS = {
   block: "▌",
   underscore: "_",
-  bar: "|", 
+  bar: "|",
   none: "\u200B",
 };
 
-export default function TypingText({ words, className, cursor = "block", config }: TypingTextProps) {
+export default function AnimateText({
+  words,
+  variant = "scramble",
+  className,
+  cursor = "bar",
+  config,
+}: AnimatedTextProps) {
   const cursorRef = useRef<HTMLSpanElement>(null);
-  const { displayed, isBusy } = useTypingAnimation(words, config);
+
+  const typing = useTypingAnimation(words, config);
+  const scramble = useScramble(words, config);
+
+  const { locked, scrambleChar, isBusy } = variant === "scramble"
+    ? scramble
+    : { locked: typing.displayed, scrambleChar: null, isBusy: typing.isBusy };
 
   useEffect(() => {
     if (isBusy) {
@@ -44,7 +60,8 @@ export default function TypingText({ words, className, cursor = "block", config 
 
   return (
     <span className={className}>
-      {displayed}
+      {locked}
+      {scrambleChar && <span className="opacity-80">{scrambleChar}</span>}
       <span ref={cursorRef}>{CURSORS[cursor]}</span>
     </span>
   );

--- a/src/components/ui/TypingText.tsx
+++ b/src/components/ui/TypingText.tsx
@@ -1,0 +1,43 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import gsap from "gsap";
+import { useTypingAnimation } from "@/hooks/animations/useTypingAnimation";
+
+interface TypingTextProps {
+  words: string[];
+  className?: string;
+  config?: {
+    pauseMs?: number;
+    typingSpeedMs?: number;
+    deletingSpeedMs?: number;
+  };
+}
+
+export default function TypingText({ words, className, config }: TypingTextProps) {
+  const cursorRef = useRef<HTMLSpanElement>(null);
+  const { displayed, isBusy } = useTypingAnimation(words, config);
+
+  useEffect(() => {
+    if (isBusy) {
+      gsap.killTweensOf(cursorRef.current);
+      gsap.set(cursorRef.current, { opacity: 1 });
+    } else {
+      gsap.to(cursorRef.current, {
+        opacity: 0,
+        repeat: -1,
+        yoyo: true,
+        duration: 0.53,
+        ease: "steps(1)",
+        delay: 0.53,
+      });
+    }
+  }, [isBusy]);
+
+  return (
+    <span className={className}>
+      {displayed}
+      <span ref={cursorRef}>█</span>
+    </span>
+  );
+}

--- a/src/components/ui/TypingText.tsx
+++ b/src/components/ui/TypingText.tsx
@@ -7,6 +7,7 @@ import { useTypingAnimation } from "@/hooks/animations/useTypingAnimation";
 interface TypingTextProps {
   words: string[];
   className?: string;
+  cursor?: "block" | "outline" | "underscore" | "bar" | "none";
   config?: {
     pauseMs?: number;
     typingSpeedMs?: number;
@@ -14,7 +15,15 @@ interface TypingTextProps {
   };
 }
 
-export default function TypingText({ words, className, config }: TypingTextProps) {
+const CURSORS = {
+  block: "█",
+  outline: "▒",
+  underscore: "_",
+  bar: "|", 
+  none: "\u200B",
+};
+
+export default function TypingText({ words, className, cursor = "none", config }: TypingTextProps) {
   const cursorRef = useRef<HTMLSpanElement>(null);
   const { displayed, isBusy } = useTypingAnimation(words, config);
 
@@ -37,7 +46,7 @@ export default function TypingText({ words, className, config }: TypingTextProps
   return (
     <span className={className}>
       {displayed}
-      <span ref={cursorRef}>█</span>
+      <span ref={cursorRef}>{CURSORS[cursor]}</span>
     </span>
   );
 }

--- a/src/components/ui/TypingText.tsx
+++ b/src/components/ui/TypingText.tsx
@@ -7,7 +7,7 @@ import { useTypingAnimation } from "@/hooks/animations/useTypingAnimation";
 interface TypingTextProps {
   words: string[];
   className?: string;
-  cursor?: "block" | "outline" | "underscore" | "bar" | "none";
+  cursor?: "block" | "underscore" | "bar" | "none";
   config?: {
     pauseMs?: number;
     typingSpeedMs?: number;
@@ -16,14 +16,13 @@ interface TypingTextProps {
 }
 
 const CURSORS = {
-  block: "█",
-  outline: "▒",
+  block: "▌",
   underscore: "_",
   bar: "|", 
   none: "\u200B",
 };
 
-export default function TypingText({ words, className, cursor = "none", config }: TypingTextProps) {
+export default function TypingText({ words, className, cursor = "block", config }: TypingTextProps) {
   const cursorRef = useRef<HTMLSpanElement>(null);
   const { displayed, isBusy } = useTypingAnimation(words, config);
 

--- a/src/hooks/animations/useHideOnScroll.ts
+++ b/src/hooks/animations/useHideOnScroll.ts
@@ -1,13 +1,13 @@
 "use client";
 
-import { useRef, useEffect } from "react";
+import { useRef, useEffect, useState } from "react";
 import { gsap } from "gsap";
 
 const CONFIG = {
-  scrollThreshold: 50, // px from top where header always shows
-  mobileBreakpoint: 1024, // px — matches Tailwind's `md`
-  showDuration: 0.18, // seconds — slide down speed
-  hideDuration: 0.18, // seconds — slide up speed
+  scrollThreshold: 50,
+  mobileBreakpoint: 1280,
+  showDuration: 0.18,
+  hideDuration: 0.18,
   showEase: "power2.out",
   hideEase: "power2.in",
 };
@@ -16,6 +16,7 @@ export function useHideOnScroll(mobileOnly = true) {
   const ref = useRef<HTMLElement | null>(null);
   const lastScrollY = useRef(0);
   const hidden = useRef(false);
+  const [isHidden, setIsHidden] = useState(false);
 
   useEffect(() => {
     const handleScroll = () => {
@@ -29,11 +30,13 @@ export function useHideOnScroll(mobileOnly = true) {
         if (hidden.current) {
           gsap.to(ref.current, { y: 0, duration: CONFIG.showDuration, ease: CONFIG.showEase });
           hidden.current = false;
+          setIsHidden(false);
         }
       } else {
         if (!hidden.current) {
           gsap.to(ref.current, { y: "-100%", duration: CONFIG.hideDuration, ease: CONFIG.hideEase });
           hidden.current = true;
+          setIsHidden(true);
         }
       }
 
@@ -44,5 +47,5 @@ export function useHideOnScroll(mobileOnly = true) {
     return () => window.removeEventListener("scroll", handleScroll);
   }, [mobileOnly]);
 
-  return ref;
-}
+  return { ref, isHidden };
+} 

--- a/src/hooks/animations/useHideOnScroll.ts
+++ b/src/hooks/animations/useHideOnScroll.ts
@@ -28,15 +28,16 @@ export function useHideOnScroll(mobileOnly = true) {
 
       if (isAtTop || isScrollingUp) {
         if (hidden.current) {
-          gsap.to(ref.current, { y: 0, duration: CONFIG.showDuration, ease: CONFIG.showEase });
-          hidden.current = false;
+          gsap.killTweensOf(ref.current);
           setIsHidden(false);
+          gsap.to(ref.current, { y: 0, duration: CONFIG.showDuration, ease: CONFIG.showEase, delay: 0.025 });
+          hidden.current = false;
         }
       } else {
         if (!hidden.current) {
-          gsap.to(ref.current, { y: "-100%", duration: CONFIG.hideDuration, ease: CONFIG.hideEase });
+          gsap.killTweensOf(ref.current);
+          gsap.to(ref.current, { y: "-100%", duration: CONFIG.hideDuration, ease: CONFIG.hideEase, onComplete: () => setIsHidden(true) });
           hidden.current = true;
-          setIsHidden(true);
         }
       }
 

--- a/src/hooks/animations/useScrambleText.ts
+++ b/src/hooks/animations/useScrambleText.ts
@@ -1,0 +1,117 @@
+import { useState, useEffect, useRef } from "react";
+
+const CONFIG = {
+  typingSpeedMs: 40, // delay between each letter being revealed
+  scrambleDurationMs: 80, // how long a letter scrambles before locking in
+  scrambleIntervalMs: 40, // how fast the scramble character cycles
+  pauseMs: 1000, // pause after the full word is revealed
+  loop: false, // repeat the sequence after the last word
+};
+const CHARS = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789@#$%&";
+
+type ScrambleConfig = Partial<typeof CONFIG>;
+
+function randomChar() {
+  return CHARS[Math.floor(Math.random() * CHARS.length)];
+}
+
+export function useScramble(words: string[], config?: ScrambleConfig) {
+  const { typingSpeedMs, scrambleDurationMs, scrambleIntervalMs, pauseMs, loop } = {
+    ...CONFIG,
+    ...config,
+  };
+
+  const [locked, setLocked] = useState("");
+  const [isBusy, setIsBusy] = useState(true);
+  const [scrambleChar, setScrambleChar] = useState<string | null>(null);
+
+  // Mutable ref holds all animation state — no cascading setState
+  const state = useRef({
+    wordIndex: 0,
+    lockedLetters: [] as string[],
+    scrambleChar: null as string | null,
+  });
+
+  useEffect(() => {
+    let cancelled = false;
+
+    // Cycles the scramble character at the current unlocked position
+    const scrambleInterval = setInterval(() => {
+      const s = state.current;
+      if (s.scrambleChar !== null) {
+        s.scrambleChar = randomChar();
+        if (!cancelled) {
+          setLocked(s.lockedLetters.join(""));
+          setScrambleChar(s.scrambleChar);
+        }
+      }
+    }, scrambleIntervalMs);
+
+    function revealWord(word: string, onDone: () => void) {
+      let pos = 0;
+
+      function revealNext() {
+        if (cancelled) return;
+        if (pos >= word.length) {
+          onDone();
+          return;
+        }
+
+        // Show scramble character at current position
+        state.current.scrambleChar = randomChar();
+
+        // Lock in correct letter after scrambleDurationMs
+        setTimeout(() => {
+          if (cancelled) return;
+          state.current.lockedLetters[pos] = word[pos];
+          state.current.scrambleChar = null;
+          setScrambleChar(null);
+          setLocked(state.current.lockedLetters.join(""));
+          pos++;
+
+          // Delay before revealing next letter
+          setTimeout(revealNext, typingSpeedMs);
+        }, scrambleDurationMs);
+      }
+
+      revealNext();
+    }
+
+    function runCycle() {
+      if (cancelled) return;
+
+      const s = state.current;
+      const word = words[s.wordIndex];
+
+      setIsBusy(true);
+      s.lockedLetters = [];
+      s.scrambleChar = null;
+      setScrambleChar(null);
+      setLocked("");
+
+      revealWord(word, () => {
+        if (cancelled) return;
+        setIsBusy(false);
+
+        const isLast = s.wordIndex === words.length - 1;
+        if (isLast && !loop) return;
+
+        setTimeout(() => {
+          if (cancelled) return;
+          s.wordIndex = (s.wordIndex + 1) % words.length;
+          runCycle();
+        }, pauseMs);
+      });
+    }
+
+    runCycle();
+
+    return () => {
+      cancelled = true;
+      clearInterval(scrambleInterval);
+    };
+  // Only re-run if the word list or config changes
+  }, [words, typingSpeedMs, scrambleDurationMs, scrambleIntervalMs, pauseMs, loop]);
+
+  return { locked, scrambleChar, isBusy };
+}

--- a/src/hooks/animations/useTypingAnimation.ts
+++ b/src/hooks/animations/useTypingAnimation.ts
@@ -1,0 +1,43 @@
+import { useState, useEffect } from "react";
+
+const CONFIG = {
+  typingSpeedMs: 80, // delay between each character typed
+  deletingSpeedMs: 40, // delay between each character deleted
+  pauseMs: 1000, // pause before starting to delete
+};
+
+type TypingConfig = Partial<typeof CONFIG>;
+
+export function useTypingAnimation(words: string[], config?: TypingConfig) {
+  const { typingSpeedMs, deletingSpeedMs, pauseMs } = { ...CONFIG, ...config };
+
+  const [displayed, setDisplayed] = useState("");
+  const [index, setIndex] = useState(0);
+  const [isDeleting, setIsDeleting] = useState(false);
+
+  useEffect(() => {
+    const current = words[index]; 
+
+    if (!isDeleting && displayed === current) {
+      const pause = setTimeout(() => setIsDeleting(true), pauseMs);
+      return () => clearTimeout(pause);
+    }
+
+    if (isDeleting && displayed === "") {
+      const next = setTimeout(() => {
+        setIsDeleting(false);
+        setIndex((prev) => (prev + 1) % words.length);
+      }, 0);
+      return () => clearTimeout(next);
+    }
+
+    const speed = isDeleting ? deletingSpeedMs : typingSpeedMs;
+    const timeout = setTimeout(() => {
+      setDisplayed(isDeleting ? current.slice(0, displayed.length - 1) : current.slice(0, displayed.length + 1));
+    }, speed);
+
+    return () => clearTimeout(timeout);
+  }, [displayed, index, isDeleting, words, typingSpeedMs, deletingSpeedMs, pauseMs]);
+
+  return { displayed, isBusy: displayed !== words[index] || isDeleting };
+}

--- a/src/hooks/animations/useTypingAnimation.ts
+++ b/src/hooks/animations/useTypingAnimation.ts
@@ -4,12 +4,13 @@ const CONFIG = {
   typingSpeedMs: 80, // delay between each character typed
   deletingSpeedMs: 40, // delay between each character deleted
   pauseMs: 1000, // pause before starting to delete
+  loop: false, // repeats the sequence once it reaches the end
 };
 
 type TypingConfig = Partial<typeof CONFIG>;
 
 export function useTypingAnimation(words: string[], config?: TypingConfig) {
-  const { typingSpeedMs, deletingSpeedMs, pauseMs } = { ...CONFIG, ...config };
+  const { typingSpeedMs, deletingSpeedMs, pauseMs, loop } = { ...CONFIG, ...config };
 
   const [displayed, setDisplayed] = useState("");
   const [index, setIndex] = useState(0);
@@ -19,6 +20,8 @@ export function useTypingAnimation(words: string[], config?: TypingConfig) {
     const current = words[index]; 
 
     if (!isDeleting && displayed === current) {
+      const isLast = index === words.length - 1;
+      if (isLast && !loop) return;
       const pause = setTimeout(() => setIsDeleting(true), pauseMs);
       return () => clearTimeout(pause);
     }
@@ -37,7 +40,7 @@ export function useTypingAnimation(words: string[], config?: TypingConfig) {
     }, speed);
 
     return () => clearTimeout(timeout);
-  }, [displayed, index, isDeleting, words, typingSpeedMs, deletingSpeedMs, pauseMs]);
+  }, [displayed, index, isDeleting, words, typingSpeedMs, deletingSpeedMs, pauseMs, loop]);
 
   return { displayed, isBusy: displayed !== words[index] || isDeleting };
 }

--- a/src/lib/site.ts
+++ b/src/lib/site.ts
@@ -5,7 +5,7 @@ export const navLinks: { href: string; label: string }[] = [
 // Profile information
 export const profileInfo = {
   name: "Luis Abhram",
-  title: "DevOps Engineer / Full-Stack Developer",
+  title: "DevOps Engineer",
   location: "Pasig City, Philippines",
   bio: "DevOps Engineer with full-stack experience. I build, deploy, and maintain scalable systems end to end.",
   image: "/avatar.png",

--- a/src/lib/site.ts
+++ b/src/lib/site.ts
@@ -8,6 +8,7 @@ export const profileInfo = {
   title: "DevOps Engineer",
   location: "Pasig City, Philippines",
   bio: "DevOps Engineer with full-stack experience. I build, deploy, and maintain scalable systems end to end.",
+  birthDate: "2003/03/26",
   image: "/avatar.png",
 }
 

--- a/src/lib/site.ts
+++ b/src/lib/site.ts
@@ -130,24 +130,3 @@ export const portfolioEasterEggMessages = [
   { text: "Okay, I'll just ignore you from now on." },
   { text: "leaves", type: "action" },
 ];
-
-// Greeting messages
-export const greetingMessages = [
-  "Hi",              // English
-  "Kamusta",      // Filipino
-  "Hola",            // Spanish
-  "Bonjour",     // French
-  "Ciao",           // Italian
-  "Hei",          // Norwegian
-  "Hallo",       // German
-  "Olá",          // Portuguese
-  "Hej",          // Swedish
-  "Hei",            // Finnish
-  "Salut",          // Romanian
-  "Ahoj",           // Czech
-  "Cześć",        // Polish
-  "Szia",      // Hungarian
-  "Merhaba",         // Turkish
-  "Sawubona",        // Zulu
-  "Habari",      // Swahili
-];

--- a/src/lib/site.ts
+++ b/src/lib/site.ts
@@ -133,21 +133,21 @@ export const portfolioEasterEggMessages = [
 
 // Greeting messages
 export const greetingMessages = [
-  "Hi, I'm",              // English
-  "Kamusta, ako si",      // Filipino
-  "Hola, soy",            // Spanish
-  "Bonjour, je suis",     // French
-  "Ciao, sono",           // Italian
-  "Hei, jeg er",          // Norwegian
-  "Hallo, ich bin",       // German
-  "Olá, eu sou",          // Portuguese
-  "Hej, jag är",          // Swedish
-  "Hei, olen",            // Finnish
-  "Salut, sunt",          // Romanian
-  "Ahoj, jsem",           // Czech
-  "Cześć, jestem",        // Polish
-  "Szia, én vagyok",      // Hungarian
-  "Merhaba, ben",         // Turkish
-  "Sawubona, ngi",        // Zulu
-  "Habari, mimi ni",      // Swahili
+  "Hi",              // English
+  "Kamusta",      // Filipino
+  "Hola",            // Spanish
+  "Bonjour",     // French
+  "Ciao",           // Italian
+  "Hei",          // Norwegian
+  "Hallo",       // German
+  "Olá",          // Portuguese
+  "Hej",          // Swedish
+  "Hei",            // Finnish
+  "Salut",          // Romanian
+  "Ahoj",           // Czech
+  "Cześć",        // Polish
+  "Szia",      // Hungarian
+  "Merhaba",         // Turkish
+  "Sawubona",        // Zulu
+  "Habari",      // Swahili
 ];

--- a/src/lib/site.ts
+++ b/src/lib/site.ts
@@ -130,3 +130,24 @@ export const portfolioEasterEggMessages = [
   { text: "Okay, I'll just ignore you from now on." },
   { text: "leaves", type: "action" },
 ];
+
+// Greeting messages
+export const greetingMessages = [
+  "Hi, I'm",              // English
+  "Kamusta, ako si",      // Filipino
+  "Hola, soy",            // Spanish
+  "Bonjour, je suis",     // French
+  "Ciao, sono",           // Italian
+  "Hei, jeg er",          // Norwegian
+  "Hallo, ich bin",       // German
+  "Olá, eu sou",          // Portuguese
+  "Hej, jag är",          // Swedish
+  "Hei, olen",            // Finnish
+  "Salut, sunt",          // Romanian
+  "Ahoj, jsem",           // Czech
+  "Cześć, jestem",        // Polish
+  "Szia, én vagyok",      // Hungarian
+  "Merhaba, ben",         // Turkish
+  "Sawubona, ngi",        // Zulu
+  "Habari, mimi ni",      // Swahili
+];


### PR DESCRIPTION
## What's Changed
- Add `AnimatedText` component (renamed from `TypingText`) with scramble animation variant
- Add GSAP blinking cursor, cursor style options, and loop option to typing animation
- Polish `Intro` section with typing animation for profile name
- Remove randomized greeting implementation and `greetingMessages`
- Add `cursor-pointer` on `TechStack` marquee when held
- Increase profile image size on desktop and reduce footer profile image size
- Update metadata title to use dynamic profile info from `site.ts`
- Add `birthDate` to `profileInfo` in `site.ts`
- Fix header gradient clipping and overflow during show/hide transitions
- Fix header background visibility above `xl` breakpoint
- Swap byline and profile image positions in footer
- Update profile title