### PR TITLE
feat: Add Spotify stats integration and layout improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,9 @@ luisabhram.dev/
 │   │   └── check.yml                     # PR validation workflow
 │   └── dependabot.yml                    # Dependabot for automatic dependency updates
 ├── lambda/
-│   └── contributions.mjs                 # GitHub contributions Lambda function
+│   ├── codingStats.mjs                   # Coding stats Lambda function
+│   ├── contributions.mjs                 # GitHub contributions Lambda function
+│   └── music.mjs                         # Music stats Lambda function
 ├── public/                               # Static assets
 ├── scripts/                              # Build-time scripts
 ├── src/
@@ -169,6 +171,11 @@ github_username    = ""
 
 # WakaTime
 wakatime_api_key   = ""
+
+# Spotify
+spotify_client_id     = ""
+spotify_client_secret = ""
+spotify_refresh_token = ""
 ```
 
 ### Provision AWS Resources
@@ -237,4 +244,5 @@ Serverless endpoints powered by AWS Lambda & API Gateway. Base URL is stored in 
 | Method | Endpoint | Description | Response |
 |---|---|---|---|
 | `GET` | `/contributions` | GitHub contributions for the previous year | `{ contributions: number }` |
-| `GET` | `/coding-stats` | WakaTime coding hours | `{ monthly: number, yearly: number }` |  <!-- add this -->
+| `GET` | `/coding-stats` | WakaTime coding hours | `{ monthly: number, yearly: number }` |
+| `GET` | `/music` | Spotify music stats | `{ topTrack, topArtist, topGenre, nowPlaying, lastPlayed }` |

--- a/lambda/music.mjs
+++ b/lambda/music.mjs
@@ -60,7 +60,7 @@ export const handler = async () => {
     // Top genre (derived from top 10 artists)
     const genreCounts = {};
     for (const a of topArtistsData?.items ?? []) {
-      for (const genre of a.genres) {
+      for (const genre of a.genres ?? []) {
         genreCounts[genre] = (genreCounts[genre] ?? 0) + 1;
       }
     }

--- a/lambda/music.mjs
+++ b/lambda/music.mjs
@@ -1,0 +1,90 @@
+const CLIENT_ID = process.env.SPOTIFY_CLIENT_ID;
+const CLIENT_SECRET = process.env.SPOTIFY_CLIENT_SECRET;
+const REFRESH_TOKEN = process.env.SPOTIFY_REFRESH_TOKEN;
+
+async function getAccessToken() {
+  const credentials = Buffer.from(`${CLIENT_ID}:${CLIENT_SECRET}`).toString("base64");
+
+  const res = await fetch("https://accounts.spotify.com/api/token", {
+    method: "POST",
+    headers: {
+      Authorization: `Basic ${credentials}`,
+      "Content-Type": "application/x-www-form-urlencoded",
+    },
+    body: new URLSearchParams({
+      grant_type: "refresh_token",
+      refresh_token: REFRESH_TOKEN,
+    }),
+  });
+
+  const data = await res.json();
+  return data.access_token;
+}
+
+async function spotifyFetch(path, token) {
+  const res = await fetch(`https://api.spotify.com/v1${path}`, {
+    headers: { Authorization: `Bearer ${token}` },
+  });
+
+  if (res.status === 204) return null;
+  return res.json();
+}
+
+function response(statusCode, body) {
+  return { statusCode, body: JSON.stringify(body) };
+}
+
+export const handler = async () => {
+  try {
+    const token = await getAccessToken();
+
+    const [topTracksData, topArtistsData, nowPlayingData, recentlyPlayedData] = await Promise.all([
+      spotifyFetch("/me/top/tracks?time_range=long_term&limit=1", token),
+      spotifyFetch("/me/top/artists?time_range=long_term&limit=10", token),
+      spotifyFetch("/me/player/currently-playing", token),
+      spotifyFetch("/me/player/recently-played?limit=1", token),
+    ]);
+
+    // Top track
+    const track = topTracksData?.items?.[0];
+    const topTrack = track
+      ? { song: track.name, artist: track.artists.map((a) => a.name).join(", "), url: track.external_urls.spotify }
+      : null;
+
+    // Top artist
+    const artist = topArtistsData?.items?.[0];
+    const topArtist = artist
+      ? { artist: artist.name, url: artist.external_urls.spotify }
+      : null;
+
+    // Top genre (derived from top 10 artists)
+    const genreCounts = {};
+    for (const a of topArtistsData?.items ?? []) {
+      for (const genre of a.genres) {
+        genreCounts[genre] = (genreCounts[genre] ?? 0) + 1;
+      }
+    }
+    const topGenre = Object.entries(genreCounts).sort((a, b) => b[1] - a[1])[0]?.[0] ?? null;
+
+    // Now playing
+    const nowPlaying = nowPlayingData?.is_playing && nowPlayingData.item
+      ? {
+          isPlaying: true,
+          song: nowPlayingData.item.name,
+          artist: nowPlayingData.item.artists.map((a) => a.name).join(", "),
+          url: nowPlayingData.item.external_urls.spotify,
+        }
+      : null;
+
+    // Last played
+    const lastTrack = recentlyPlayedData?.items?.[0]?.track;
+    const lastPlayed = lastTrack
+      ? { song: lastTrack.name, artist: lastTrack.artists.map((a) => a.name).join(", "), url: lastTrack.external_urls.spotify }
+      : null;
+
+    return response(200, { topTrack, topArtist, topGenre, nowPlaying, lastPlayed });
+  } catch (error) {
+    console.error("Spotify Lambda error:", error);
+    return response(500, { error: "Internal server error" });
+  }
+};

--- a/src/components/sections/Stats.tsx
+++ b/src/components/sections/Stats.tsx
@@ -88,7 +88,7 @@ export default function Stats() {
     <section className="w-full">
       <div className="mx-auto flex max-w-4xl flex-col gap-10 px-6 sm:px-10">
         <SectionTitle title="Stats" />
-        <ul className="flex flex-col gap-6">
+        <ul className="grid grid-cols-1 gap-6 sm:grid-cols-2">
           {stats.map((stat, i) => (
             <li key={i} className="flex items-start gap-4 text-zinc-600 dark:text-zinc-400">
               <span className="flex h-5 w-5 shrink-0 items-center justify-center text-zinc-400">{stat.icon}</span>

--- a/src/components/sections/Stats.tsx
+++ b/src/components/sections/Stats.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import { MdLocationPin, MdCode, MdAccessTime, MdCalendarMonth } from "react-icons/md";
+import { MdLocationPin, MdCode, MdAccessTime, MdCalendarMonth, MdMusicNote, MdHeadphones } from "react-icons/md";
 import { profileInfo } from "@/lib/site";
 import SectionTitle from "./common/SectionTitle";
 import Skeleton from "@/components/ui/Skeleton";
@@ -39,11 +39,32 @@ async function fetchCodingStats(): Promise<{ monthly: number; yearly: number } |
   }
 }
 
+type MusicStats = {
+  nowPlaying: { song: string; artist: string; url: string; isPlaying: boolean } | null;
+  lastPlayed: { song: string; artist: string; url: string } | null;
+  topTrack: { song: string; artist: string; url: string } | null;
+};
+
+async function fetchMusicStats(): Promise<MusicStats | null> {
+  const url = process.env.NEXT_PUBLIC_API_URL;
+  if (!url) return null;
+
+  try {
+    const res = await fetch(`${url}/music`);
+    const result = await res.json();
+    return result ?? null;
+  } catch (error) {
+    console.error("Network or Parsing Error:", error);
+    return null;
+  }
+}
+
 export default function Stats() {
   const [age, setAge] = useState("—");
   const [time, setTime] = useState<{ time: string; offset: string } | null>(null);
   const [contributions, setContributions] = useState<number | null>(null);
   const [codingStats, setCodingStats] = useState<{ monthly: number; yearly: number } | null>(null);
+  const [musicStats, setMusicStats] = useState<MusicStats | null>(null);
 
   useEffect(() => {
     const interval = setInterval(() => {
@@ -53,6 +74,7 @@ export default function Stats() {
 
     fetchContributions().then(setContributions);
     fetchCodingStats().then(setCodingStats);
+    fetchMusicStats().then(setMusicStats);
 
     return () => clearInterval(interval);
   }, []);
@@ -82,24 +104,43 @@ export default function Stats() {
       sublabel: <><span className="font-mono">{codingStats?.yearly.toLocaleString()}</span> hours coded this year</>,
       ready: codingStats !== null,
     },
+    {
+      icon: <MdMusicNote size={18} />,
+      label: (() => {
+        const track = musicStats?.nowPlaying ?? musicStats?.lastPlayed;
+        return track
+          ? <><a href={track.url} target="_blank" rel="noopener noreferrer" className="underline">{track.song}</a> by {track.artist}</>
+          : "-";
+      })(),
+      sublabel: musicStats?.nowPlaying ? "Currently playing" : "Recently played",
+      ready: musicStats !== null,
+    },
+    {
+      icon: <MdHeadphones size={18} />,
+      label: musicStats?.topTrack
+        ? <><a href={musicStats.topTrack.url} target="_blank" rel="noopener noreferrer" className="underline">{musicStats.topTrack.song}</a> by {musicStats.topTrack.artist}</>
+        : "-",
+      sublabel: "Top track this year",
+      ready: musicStats !== null,
+    },
   ];
 
   return (
     <section className="w-full">
       <div className="mx-auto flex max-w-4xl flex-col gap-10 px-6 sm:px-10">
         <SectionTitle title="Stats" />
-        <ul className="grid grid-cols-1 gap-6 sm:grid-cols-2">
+        <ul className="columns-1 gap-6 sm:columns-2 md:columns-3">
           {stats.map((stat, i) => (
-            <li key={i} className="flex items-start gap-4 text-zinc-600 dark:text-zinc-400">
+            <li key={i} className="break-inside-avoid mb-6 flex items-start gap-4 text-zinc-600 dark:text-zinc-400">
               <span className="flex h-5 w-5 shrink-0 items-center justify-center text-zinc-400">{stat.icon}</span>
-              <div className="flex flex-col gap-1">
+              <div className="flex min-w-0 flex-col gap-1">
                 {stat.ready ? (
-                  <span className="leading-5 text-base text-zinc-800 dark:text-zinc-200">{stat.label}</span>
+                  <span className="leading-5 truncate text-base text-zinc-800 dark:text-zinc-200">{stat.label}</span>
                 ) : (
                   <Skeleton shape="pill" className="h-5 w-48" />
                 )}
                 {stat.ready ? (
-                  <span className="leading-5 text-sm text-zinc-600 dark:text-zinc-400">{stat.sublabel}</span>
+                  <span className="leading-5 truncate text-sm text-zinc-600 dark:text-zinc-400">{stat.sublabel}</span>
                 ) : (
                   <Skeleton shape="pill" className="h-5 w-48" />
                 )}

--- a/src/components/sections/Stats.tsx
+++ b/src/components/sections/Stats.tsx
@@ -59,6 +59,18 @@ export default function Stats() {
 
   const stats: { icon: React.ReactNode; label: React.ReactNode; sublabel: React.ReactNode; ready: boolean }[] = [
     {
+      icon: <MdCalendarMonth size={18} />,
+      label: <><AnimateText words={[age]} variant="slot" cursor="none" className="text-base leading-5" /> years old</>,
+      sublabel: <><AnimateText words={[String(getDaysUntilBirthday(profileInfo.birthDate))]} variant="slot" cursor="none" /> days until next birthday</>,
+      ready: age !== "—",
+    },
+    {
+      icon: <MdLocationPin size={18} />,
+      label: `Currently in ${COUNTRY}`,
+      sublabel: <><AnimateText words={[time?.time ?? "—"]} variant="slot" cursor="none" /> {time?.offset}</>,
+      ready: time !== null,
+    },
+    {
       icon: <MdCode size={18} />,
       label: <><span className="font-mono">{contributions?.toLocaleString()}</span> contributions</>,
       sublabel: "On GitHub in the last year",
@@ -69,18 +81,6 @@ export default function Stats() {
       label: <><span className="font-mono">{codingStats?.monthly.toLocaleString()}</span> hours coded this month</>,
       sublabel: <><span className="font-mono">{codingStats?.yearly.toLocaleString()}</span> hours coded this year</>,
       ready: codingStats !== null,
-    },
-      {
-      icon: <MdLocationPin size={18} />,
-      label: `Currently in ${COUNTRY}`,
-      sublabel: <><AnimateText words={[time?.time ?? "—"]} variant="slot" cursor="none" /> {time?.offset}</>,
-      ready: time !== null,
-    },
-    {
-      icon: <MdCalendarMonth size={18} />,
-      label: <><AnimateText words={[age]} variant="slot" cursor="none" className="text-base leading-5" /> years old</>,
-      sublabel: <><AnimateText words={[String(getDaysUntilBirthday(profileInfo.birthDate))]} variant="slot" cursor="none" /> days until next birthday</>,
-      ready: age !== "—",
     },
   ];
 

--- a/terraform/lambda.tf
+++ b/terraform/lambda.tf
@@ -118,3 +118,47 @@ resource "aws_lambda_permission" "coding_stats" {
   principal     = "apigateway.amazonaws.com"
   source_arn    = "${aws_apigatewayv2_api.api.execution_arn}/*/*"
 }
+
+# Music (Spotify) Endpoint
+data "archive_file" "music" {
+  type        = "zip"
+  source_file = "${path.module}/../lambda/music.mjs"
+  output_path = "${path.module}/../lambda/music.zip"
+}
+
+resource "aws_lambda_function" "music" {
+  filename         = data.archive_file.music.output_path
+  function_name    = "${var.project_name}-music"
+  role             = aws_iam_role.lambda_shared.arn
+  handler          = "music.handler"
+  runtime          = "nodejs20.x"
+  source_code_hash = data.archive_file.music.output_base64sha256
+
+  environment {
+    variables = {
+      SPOTIFY_CLIENT_ID     = var.spotify_client_id
+      SPOTIFY_CLIENT_SECRET = var.spotify_client_secret
+      SPOTIFY_REFRESH_TOKEN = var.spotify_refresh_token
+    }
+  }
+}
+
+resource "aws_apigatewayv2_integration" "music" {
+  api_id                 = aws_apigatewayv2_api.api.id
+  integration_type       = "AWS_PROXY"
+  integration_uri        = aws_lambda_function.music.invoke_arn
+  payload_format_version = "2.0"
+}
+
+resource "aws_apigatewayv2_route" "music" {
+  api_id    = aws_apigatewayv2_api.api.id
+  route_key = "GET /music"
+  target    = "integrations/${aws_apigatewayv2_integration.music.id}"
+}
+
+resource "aws_lambda_permission" "music" {
+  action        = "lambda:InvokeFunction"
+  function_name = aws_lambda_function.music.function_name
+  principal     = "apigateway.amazonaws.com"
+  source_arn    = "${aws_apigatewayv2_api.api.execution_arn}/*/*"
+}

--- a/terraform/lambda.tf
+++ b/terraform/lambda.tf
@@ -46,7 +46,7 @@ resource "aws_lambda_function" "contributions" {
   function_name    = "${var.project_name}-contributions"
   role             = aws_iam_role.lambda_shared.arn
   handler          = "contributions.handler"
-  runtime          = "nodejs20.x"
+  runtime          = "nodejs22.x"
   source_code_hash = data.archive_file.contributions.output_base64sha256
 
   environment {
@@ -89,8 +89,9 @@ resource "aws_lambda_function" "coding_stats" {
   function_name    = "${var.project_name}-coding-stats"
   role             = aws_iam_role.lambda_shared.arn
   handler          = "codingStats.handler"
-  runtime          = "nodejs20.x"
+  runtime          = "nodejs22.x"
   source_code_hash = data.archive_file.coding_stats.output_base64sha256
+  timeout = 10
 
   environment {
     variables = {
@@ -131,8 +132,9 @@ resource "aws_lambda_function" "music" {
   function_name    = "${var.project_name}-music"
   role             = aws_iam_role.lambda_shared.arn
   handler          = "music.handler"
-  runtime          = "nodejs20.x"
+  runtime          = "nodejs22.x"
   source_code_hash = data.archive_file.music.output_base64sha256
+  timeout = 15
 
   environment {
     variables = {

--- a/terraform/terraform.tfvars.example
+++ b/terraform/terraform.tfvars.example
@@ -20,3 +20,8 @@ github_username    = ""
 
 # WakaTime
 wakatime_api_key   = ""
+
+# Spotify
+spotify_client_id     = "your_client_id"
+spotify_client_secret = "your_client_secret"
+spotify_refresh_token = "your_refresh_token"

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -57,6 +57,22 @@ variable "github_username" {
 
 # WakaTime
 variable "wakatime_api_key" {
-  description = "WakaTime API key for coding stats"
+  description = "WakaTime API key for coding stats API"
+  sensitive   = true
+}
+
+# Spotify
+variable "spotify_client_id" {
+  description = "Spotify client ID for music stats API"
+  sensitive   = true
+}
+
+variable "spotify_client_secret" {
+  description = "Spotify client secret for music stats API"
+  sensitive   = true
+}
+
+variable "spotify_refresh_token" {
+  description = "Spotify refresh token for music stats API"
   sensitive   = true
 }


### PR DESCRIPTION
## What's Changed?

### What's New
* **Spotify Integration:** Added a new Lambda endpoint and infrastructure to fetch and display music statistics.
* **Top Track Stat:** Replaced the "top genre" display with a "top track" metric.
* **Multi-Column Layout:** Implemented a 3-column layout for larger screens and a grid system starting at the small breakpoint.

### Refactors & Improvements
* **Stats Hierarchy:** Reordered the display to prioritize age and location stats at the top of the section.
* **Infrastructure:** Upgraded the AWS Lambda runtime to Node.js 22.x and adjusted configurations to prevent API timeouts.

### Fixes
* **Data Handling:** Added safety checks to handle undefined genres in the top artists data to prevent crashes.
* **Styling:** Refined the responsiveness of the stats grid for better consistency across screen sizes.