### PR TITLE
feat: Add tooltip and add animation to stat labels

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -42,4 +42,8 @@
   .font-consolas {
     font-family: Consolas, monospace;
   }
+
+  .scrollbar-gutter-auto {
+    scrollbar-gutter: auto;
+  }
 }

--- a/src/components/layout/footer/Footer.tsx
+++ b/src/components/layout/footer/Footer.tsx
@@ -18,7 +18,7 @@ export default function Footer() {
 
       {/* Footer Image */}
       <button onClick={() => window.scrollTo({ top: 0, behavior: "smooth" })}>
-        <ProfileImage width={48} height={48} />
+        <ProfileImage width={48} height={48} className="hover:scale-112 transition-transform"/>
       </button>
 
       {/* Social Links */}

--- a/src/components/sections/Intro.tsx
+++ b/src/components/sections/Intro.tsx
@@ -50,8 +50,8 @@ export default function Intro() {
       <div className="flex flex-col mx-auto px-6 sm:flex-row sm:justify-between sm:gap-12 sm:items-center sm:px-10">
         <div className="flex flex-col gap-4 sm:gap-6">
           {/* Profile Image - Small Screens */}
-          <div className="shrink-0 sm:hidden ">
-            <ProfileImage width={64} height={64} />
+          <div className="shrink-0 sm:hidden">
+            <ProfileImage width={64} height={64}/>
           </div>
 
           {/* Name */}
@@ -101,7 +101,7 @@ export default function Intro() {
 
         {/* Profile Image - Large Screens */}
         <div className="shrink-0 hidden sm:block">
-          <ProfileImage width={160} height={160} />
+          <ProfileImage width={160} height={160}/>
         </div>
       </div>
     </section>

--- a/src/components/sections/Stats.tsx
+++ b/src/components/sections/Stats.tsx
@@ -8,6 +8,7 @@ import Skeleton from "@/components/ui/Skeleton";
 import AnimateText from "@/components/ui/AnimatedText";
 import { getAge, getDaysUntilBirthday, getLocalTime } from "@/lib/utils/profile";
 import useTextMarquee from "@/hooks/animations/useTextMarquee";
+import Tooltip from "@/components/ui/Tooltip";
 
 const TIMEZONE = "Asia/Manila";
 const COUNTRY = "Philippines";
@@ -70,6 +71,19 @@ type StatItemType = {
 
 function StatItem({ stat }: { stat: StatItemType }) {
   const { ref } = useTextMarquee(stat.labelText, stat.ready);
+  const [isOverflowing, setIsOverflowing] = useState(false);
+
+  useEffect(() => {
+    const el = ref.current;
+    if (!el || !stat.ready) return;
+
+    const observer = new ResizeObserver(() => {
+      setIsOverflowing(el.scrollWidth > el.clientWidth);
+    });
+
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, [stat.ready, ref]);
 
   return (
     <li className="break-inside-avoid mb-6 flex items-start gap-4 text-zinc-600 dark:text-zinc-400">
@@ -78,9 +92,11 @@ function StatItem({ stat }: { stat: StatItemType }) {
       </span>
       <div className="flex min-w-0 flex-col gap-1">
         {stat.ready ? (
-          <span ref={ref} className="overflow-hidden whitespace-nowrap pr-2 leading-5 text-base text-zinc-800 dark:text-zinc-200">
-            {stat.label}
-          </span>
+          <Tooltip content={stat.labelText ?? ""} disabled={!isOverflowing}>
+            <span ref={ref} className="block overflow-hidden whitespace-nowrap pr-2 sm:pr-1 leading-5 text-base text-zinc-800 dark:text-zinc-200">
+              {stat.label}
+            </span>
+          </Tooltip>
         ) : (
           <Skeleton shape="pill" className="h-5 w-48" />
         )}

--- a/src/components/sections/Stats.tsx
+++ b/src/components/sections/Stats.tsx
@@ -93,7 +93,7 @@ function StatItem({ stat }: { stat: StatItemType }) {
       <div className="flex min-w-0 flex-col gap-1">
         {stat.ready ? (
           <Tooltip content={stat.labelText ?? ""} disabled={!isOverflowing}>
-            <span ref={ref} className="block overflow-hidden whitespace-nowrap pr-2 sm:pr-1 leading-5 text-base text-zinc-800 dark:text-zinc-200">
+            <span ref={ref} className="block overflow-hidden scrollbar-gutter-auto whitespace-nowrap pr-2 sm:pr-1 leading-5 text-base text-zinc-800 dark:text-zinc-200">
               {stat.label}
             </span>
           </Tooltip>

--- a/src/components/sections/Stats.tsx
+++ b/src/components/sections/Stats.tsx
@@ -7,6 +7,7 @@ import SectionTitle from "./common/SectionTitle";
 import Skeleton from "@/components/ui/Skeleton";
 import AnimateText from "@/components/ui/AnimatedText";
 import { getAge, getDaysUntilBirthday, getLocalTime } from "@/lib/utils/profile";
+import useTextMarquee from "@/hooks/animations/useTextMarquee";
 
 const TIMEZONE = "Asia/Manila";
 const COUNTRY = "Philippines";
@@ -59,6 +60,42 @@ async function fetchMusicStats(): Promise<MusicStats | null> {
   }
 }
 
+type StatItemType = {
+  icon: React.ReactNode;
+  label: React.ReactNode;
+  labelText?: string;
+  sublabel: React.ReactNode;
+  ready: boolean;
+};
+
+function StatItem({ stat }: { stat: StatItemType }) {
+  const { ref } = useTextMarquee(stat.labelText, stat.ready);
+
+  return (
+    <li className="break-inside-avoid mb-6 flex items-start gap-4 text-zinc-600 dark:text-zinc-400">
+      <span className="flex h-5 w-5 shrink-0 items-center justify-center text-zinc-400">
+        {stat.icon}
+      </span>
+      <div className="flex min-w-0 flex-col gap-1">
+        {stat.ready ? (
+          <span ref={ref} className="overflow-hidden whitespace-nowrap pr-2 leading-5 text-base text-zinc-800 dark:text-zinc-200">
+            {stat.label}
+          </span>
+        ) : (
+          <Skeleton shape="pill" className="h-5 w-48" />
+        )}
+        {stat.ready ? (
+          <span className="leading-5 truncate text-sm text-zinc-600 dark:text-zinc-400">
+            {stat.sublabel}
+          </span>
+        ) : (
+          <Skeleton shape="pill" className="h-5 w-48" />
+        )}
+      </div>
+    </li>
+  );
+}
+
 export default function Stats() {
   const [age, setAge] = useState("—");
   const [time, setTime] = useState<{ time: string; offset: string } | null>(null);
@@ -79,7 +116,9 @@ export default function Stats() {
     return () => clearInterval(interval);
   }, []);
 
-  const stats: { icon: React.ReactNode; label: React.ReactNode; sublabel: React.ReactNode; ready: boolean }[] = [
+  const nowOrLast = musicStats?.nowPlaying ?? musicStats?.lastPlayed;
+
+  const stats: StatItemType[] = [
     {
       icon: <MdCalendarMonth size={18} />,
       label: <><AnimateText words={[age]} variant="slot" cursor="none" className="leading-5" /> years old</>,
@@ -106,12 +145,10 @@ export default function Stats() {
     },
     {
       icon: <MdMusicNote size={18} />,
-      label: (() => {
-        const track = musicStats?.nowPlaying ?? musicStats?.lastPlayed;
-        return track
-          ? <><a href={track.url} target="_blank" rel="noopener noreferrer" className="underline">{track.song}</a> by {track.artist}</>
-          : "-";
-      })(),
+      label: nowOrLast
+        ? <><a href={nowOrLast.url} target="_blank" rel="noopener noreferrer" className="underline">{nowOrLast.song}</a> by {nowOrLast.artist}</>
+        : "-",
+      labelText: nowOrLast ? `${nowOrLast.song} by ${nowOrLast.artist}` : undefined,
       sublabel: musicStats?.nowPlaying ? "Currently playing" : "Recently played",
       ready: musicStats !== null,
     },
@@ -120,6 +157,7 @@ export default function Stats() {
       label: musicStats?.topTrack
         ? <><a href={musicStats.topTrack.url} target="_blank" rel="noopener noreferrer" className="underline">{musicStats.topTrack.song}</a> by {musicStats.topTrack.artist}</>
         : "-",
+      labelText: musicStats?.topTrack ? `${musicStats.topTrack.song} by ${musicStats.topTrack.artist}` : undefined,
       sublabel: "Top track this year",
       ready: musicStats !== null,
     },
@@ -131,27 +169,7 @@ export default function Stats() {
         <SectionTitle title="Stats" />
         <ul className="columns-1 gap-6 sm:columns-2 md:columns-3">
           {stats.map((stat, i) => (
-            <li key={i} className="break-inside-avoid mb-6 flex items-start gap-4 text-zinc-600 dark:text-zinc-400">
-              <span className="flex h-5 w-5 shrink-0 items-center justify-center text-zinc-400">
-                {stat.icon}
-              </span>
-              <div className="flex min-w-0 flex-col gap-1">
-                {stat.ready ? (
-                  <span className="leading-5 truncate text-base text-zinc-800 dark:text-zinc-200">
-                    {stat.label}
-                  </span>
-                ) : (
-                  <Skeleton shape="pill" className="h-5 w-48" />
-                )}
-                {stat.ready ? (
-                  <span className="leading-5 truncate text-sm text-zinc-600 dark:text-zinc-400">
-                    {stat.sublabel}
-                  </span>
-                ) : (
-                  <Skeleton shape="pill" className="h-5 w-48" />
-                )}
-              </div>
-            </li>
+            <StatItem key={i} stat={stat} />
           ))}
         </ul>
       </div>

--- a/src/components/sections/common/ProfileImage.tsx
+++ b/src/components/sections/common/ProfileImage.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { cn } from "@/lib/utils/cn";
 import { useState } from "react";
 import Image from "next/image";
 import { profileInfo } from "@/lib/site";
@@ -8,9 +9,11 @@ import Skeleton from "@/components/ui/Skeleton";
 type Props = {
   width: number;
   height: number;
+  className?: string;
 };
 
-export default function ProfileImage({ width, height }: Props) {
+export default function ProfileImage({ width, height, className }: Props) {
+  console.log(className);
   const [loaded, setLoaded] = useState(false);
 
   return (
@@ -29,7 +32,11 @@ export default function ProfileImage({ width, height }: Props) {
         height={height}
         priority
         onLoad={() => setLoaded(true)}
-        className={`rounded-full object-cover ${loaded ? "block" : "hidden"}`}
+        className={cn(
+          "rounded-full object-cover",
+          loaded ? "block" : "hidden",
+          className
+        )}
       />
     </>
   );

--- a/src/components/ui/Tooltip.tsx
+++ b/src/components/ui/Tooltip.tsx
@@ -1,0 +1,61 @@
+"use client";
+
+import { useState, useRef, useCallback, useEffect } from "react";
+
+type Props = {
+  content: string;
+  disabled?: boolean;
+  children: React.ReactNode;
+};
+
+type Position = "top" | "bottom";
+
+export default function Tooltip({ content, disabled = false, children }: Props) {
+  const [visible, setVisible] = useState(false);
+  const [position, setPosition] = useState<Position>("top");
+  const triggerRef = useRef<HTMLDivElement>(null);
+
+  const updatePosition = useCallback(() => {
+    const el = triggerRef.current;
+    if (!el) return;
+    const rect = el.getBoundingClientRect();
+    const spaceAbove = rect.top;
+    const spaceBelow = window.innerHeight - rect.bottom;
+    setPosition(spaceAbove >= spaceBelow ? "top" : "bottom");
+  }, []);
+
+  const show = useCallback(() => {
+    if (disabled) return;
+    updatePosition();
+    setVisible(true);
+  }, [disabled, updatePosition]);
+
+  const hide = useCallback(() => setVisible(false), []);
+
+  useEffect(() => {
+    if (!visible) return;
+    window.addEventListener("scroll", hide, { passive: true });
+    return () => window.removeEventListener("scroll", hide);
+  }, [visible, hide]);
+
+  return (
+    <div
+      ref={triggerRef}
+      className="relative min-w-0"
+      onMouseEnter={show}
+      onMouseLeave={hide}
+      onFocus={show}
+      onBlur={hide}
+    >
+      {children}
+      {visible && (
+        <div
+          role="tooltip"
+          className={`${position === "top" ? "bottom-full mb-2" : "top-full mt-2"} pointer-events-none absolute left-0 z-50 w-max max-w-xs rounded-md border border-zinc-200 dark:border-zinc-700 bg-white dark:bg-zinc-900 px-2.5 py-1.5 text-sm text-zinc-800 dark:text-zinc-200 shadow-md`}
+        >
+          {content}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/ui/Tooltip.tsx
+++ b/src/components/ui/Tooltip.tsx
@@ -14,6 +14,7 @@ export default function Tooltip({ content, disabled = false, children }: Props) 
   const [visible, setVisible] = useState(false);
   const [position, setPosition] = useState<Position>("top");
   const triggerRef = useRef<HTMLDivElement>(null);
+  const [offsetX, setOffsetX] = useState(0);
 
   const updatePosition = useCallback(() => {
     const el = triggerRef.current;
@@ -22,6 +23,15 @@ export default function Tooltip({ content, disabled = false, children }: Props) 
     const spaceAbove = rect.top;
     const spaceBelow = window.innerHeight - rect.bottom;
     setPosition(spaceAbove >= spaceBelow ? "top" : "bottom");
+
+    // Shift tooltip left if it would overflow the right edge
+    const tooltipMaxWidth = 320;
+    const rightEdge = rect.left + tooltipMaxWidth;
+    if (rightEdge > window.innerWidth) {
+      setOffsetX(window.innerWidth - rightEdge - 8);
+    } else {
+      setOffsetX(0);
+    }
   }, []);
 
   const show = useCallback(() => {
@@ -51,6 +61,7 @@ export default function Tooltip({ content, disabled = false, children }: Props) 
       {visible && (
         <div
           role="tooltip"
+          style={{ left: offsetX }}
           className={`${position === "top" ? "bottom-full mb-2" : "top-full mt-2"} pointer-events-none absolute left-0 z-50 w-max max-w-xs rounded-md border border-zinc-200 dark:border-zinc-700 bg-white dark:bg-zinc-900 px-2.5 py-1.5 text-sm text-zinc-800 dark:text-zinc-200 shadow-md`}
         >
           {content}

--- a/src/hooks/animations/useTextMarquee.ts
+++ b/src/hooks/animations/useTextMarquee.ts
@@ -1,0 +1,59 @@
+import { useRef, useEffect, useCallback } from "react";
+
+const CONFIG = {
+  pauseStart: 2.7, // seconds to pause before sliding
+  pauseEnd: 3.7, // seconds to pause after reaching the end
+  pixelsPerStep: 1, // pixels to move per step
+  stepInterval: 16, // ms per step (~60fps)
+};
+
+export default function useTextMarquee(labelText: string | undefined, ready: boolean) {
+  const ref = useRef<HTMLSpanElement>(null);
+  const animateRef = useRef<() => (() => void) | undefined>(undefined);
+
+  const animate = useCallback(() => {
+    const el = ref.current;
+    if (!el || !labelText) return;
+
+    // not truncated, skip
+    const isOverflowing = el.scrollWidth > el.clientWidth;
+    if (!isOverflowing) return;
+
+    const maxScroll = el.scrollWidth - el.clientWidth;
+    let cancelled = false;
+
+    const pauseStartTimer = setTimeout(() => {
+      const interval = setInterval(() => {
+        if (cancelled) return clearInterval(interval);
+
+        el.scrollLeft += CONFIG.pixelsPerStep;
+
+        if (el.scrollLeft >= maxScroll) {
+          clearInterval(interval);
+
+          const pauseEndTimer = setTimeout(() => {
+            el.scrollLeft = 0;
+            if (!cancelled) setTimeout(() => animateRef.current?.(), CONFIG.pauseStart * 1000)
+          }, CONFIG.pauseEnd * 1000);
+
+          return () => clearTimeout(pauseEndTimer);
+        }
+      }, CONFIG.stepInterval);
+    }, CONFIG.pauseStart * 1000);
+
+    return () => {
+      cancelled = true;
+      clearTimeout(pauseStartTimer);
+      el.scrollLeft = 0;
+    };
+  }, [labelText]);
+
+  useEffect(() => {
+    if (!ready || !labelText) return;
+    animateRef.current = animate;
+    const cleanup = animate();
+    return cleanup;
+  }, [ready, labelText, animate]);
+
+  return { ref };
+}

--- a/src/hooks/animations/useTextMarquee.ts
+++ b/src/hooks/animations/useTextMarquee.ts
@@ -33,7 +33,7 @@ export default function useTextMarquee(labelText: string | undefined, ready: boo
 
           const pauseEndTimer = setTimeout(() => {
             el.scrollLeft = 0;
-            if (!cancelled) setTimeout(() => animateRef.current?.(), CONFIG.pauseStart * 1000)
+            if (!cancelled) animateRef.current?.();
           }, CONFIG.pauseEnd * 1000);
 
           return () => clearTimeout(pauseEndTimer);

--- a/src/hooks/animations/useTextMarquee.ts
+++ b/src/hooks/animations/useTextMarquee.ts
@@ -33,7 +33,7 @@ export default function useTextMarquee(labelText: string | undefined, ready: boo
 
           const pauseEndTimer = setTimeout(() => {
             el.scrollLeft = 0;
-            if (!cancelled) animateRef.current?.();
+            if (!cancelled) requestAnimationFrame(() => animateRef.current?.());
           }, CONFIG.pauseEnd * 1000);
 
           return () => clearTimeout(pauseEndTimer);


### PR DESCRIPTION
## What's Changed?

### What's New
* **Tooltip Component:** Introduced a reusable Tooltip component to provide context for long stat labels.
* **Text Marquee:** Added a smooth marquee scrolling effect for stat labels that exceed their container width.
* **Component Flexibility:** Added `className` prop support to the `ProfileImage` component for better styling control.

### Fixes
* **Tooltip Layout:** Fixed an issue where tooltips would overflow horizontally on mobile devices.
* **Animation Logic:** Resolved a "double pause" glitch during the animation reset of the text marquee.
* **Chromium Scroll Issue:** Overrode `scrollbar-gutter` on the marquee component to fix a bug where the scroll would reset incorrectly in Chromium-based browsers.