### PR TITLE
fix: Update typography and UI styling across sections

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,13 +31,11 @@ The site is live at [luisabhram.dev](https://luisabhram.dev)
 - **Animations:** GSAP
 
 ### Infrastructure
-- **Hosting:** AWS S3
-- **CDN:** AWS CloudFront
-- **SSL:** AWS Certificate Manager
-- **DNS:** Cloudflare
+- **Frontend Hosting:** AWS S3 & AWS CloudFront 
+- **Serverless Backend:** AWS Lambda & API Gateway  
+- **DNS & Security:** Cloudflare (DNS) & AWS ACM (SSL)
 - **IaC:** Terraform
-- **Serverless:** AWS Lambda & API Gateway
-- **Error Monitoring:** Sentry
+- **Observability:** Sentry (Errors), AWS CloudWatch (Logs + Metrics)
 - **Analytics:** Google Analytics
 
 ### CI/CD

--- a/src/components/sections/Career.tsx
+++ b/src/components/sections/Career.tsx
@@ -33,7 +33,7 @@ export default function Career() {
                       <a href={work.website} target="_blank" rel="noopener noreferrer" className={work.website ? "underline sm:no-underline sm:hover:underline" : ""}>
                         {work.company}
                         {work.website && (
-                          <IconArrowUpRight size={18} className="sm:hidden inline mb-0.5 overflow-clip" />
+                          <IconArrowUpRight size={18} className="sm:hidden inline mb-0.5 overflow-clip  text-zinc-400 dark:text-zinc-500" />
                         )}
                       </a>
                     </span>

--- a/src/components/sections/Education.tsx
+++ b/src/components/sections/Education.tsx
@@ -31,7 +31,7 @@ export default function Education() {
                         <a href={edu.website} target="_blank" rel="noopener noreferrer" className={edu.website ? "underline sm:no-underline sm:hover:underline" : ""}>
                           {edu.school}
                           {edu.website && (
-                            <IconArrowUpRight size={18} className="sm:hidden inline mb-0.5 overflow-clip" />
+                            <IconArrowUpRight size={18} className="sm:hidden inline mb-0.5 overflow-clip text-zinc-400 dark:text-zinc-500" />
                           )}
                         </a>
                       </span>

--- a/src/components/sections/Stats.tsx
+++ b/src/components/sections/Stats.tsx
@@ -150,7 +150,7 @@ export default function Stats() {
     {
       icon: <IconMapPin size={18} />,
       label: `Currently in ${COUNTRY}`,
-      sublabel: <><AnimateText words={[time?.time ?? "—"]} variant="slot" cursor="none" /> <span className="font-mono">({time?.offset})</span> </>,
+      sublabel: <><AnimateText words={[time?.time ?? "—"]} variant="slot" cursor="none" /> <span>({time?.offset})</span> </>,
       ready: time !== null,
     },
     {

--- a/src/components/ui/Tooltip.tsx
+++ b/src/components/ui/Tooltip.tsx
@@ -62,7 +62,7 @@ export default function Tooltip({ content, disabled = false, children }: Props) 
         <div
           role="tooltip"
           style={{ left: offsetX }}
-          className={`${position === "top" ? "bottom-full mb-2" : "top-full mt-2"} pointer-events-none absolute left-0 z-50 w-max max-w-xs rounded-md border border-zinc-200 dark:border-zinc-700 bg-zinc-100 dark:bg-zinc-900 px-2.5 py-1.5 text-sm text-zinc-800 dark:text-zinc-200 shadow-md`}
+          className={`${position === "top" ? "bottom-full mb-2" : "top-full mt-2"} pointer-events-none absolute left-0 z-50 w-max max-w-xs rounded-md border border-zinc-200 dark:border-zinc-700 bg-zinc-100 dark:bg-zinc-900 px-2.5 py-1.5 text-xs text-zinc-800 dark:text-zinc-200 shadow-md`}
         >
           {content}
         </div>


### PR DESCRIPTION
## What's Changed?

### Fixes
* **Typography:** Update the sublabel span in the location stat to remove `font-mono`, ensuring visual consistency with other labels.
* **UI Styling:** Update the arrow icon color for website links in the Career and Education sections for better visibility on mobile screens.
* **Tooltip Refinement:** Change the tooltip text size from `sm` to `xs` to improve the component's compact footprint.

### Documentation & Maintenance
* **Infrastructure:** Adjust the `README.md` tech stack section to accurately reflect the current infrastructure setup.