### PR TITLE
feat: Integrate GitHub contribution graph and reorder stats

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,7 +258,7 @@ Serverless endpoints powered by AWS Lambda & API Gateway. Base URL is stored in 
 
 | Method | Endpoint | Description | Response |
 |---|---|---|---|
-| `GET` | `/github` | GitHub profile stats | `{ contributions, totalCommits, recentPortfolioCommits, recentActivity }` |
+| `GET` | `/github` | GitHub profile stats | `{ contributions, totalCommits, weeks, recentPortfolioCommits, recentActivity }` |
 | `GET` | `/wakatime` | WakaTime coding hours | `{ monthly: number, yearly: number }` |
 | `GET` | `/spotify` | Spotify music stats | `{ topTrack, topArtist, nowPlaying, lastPlayed }` |
 | `GET` | `/monkeytype` | Monkeytype personal bests | `{ time: { 15/60 { wpm, acc, consistency, timestamp } } }` |

--- a/lambda/github.mjs
+++ b/lambda/github.mjs
@@ -21,20 +21,25 @@ export const handler = async () => {
 
     const token = process.env.GITHUB_TOKEN;
     const username = process.env.GITHUB_USERNAME;
-    const year = new Date().getFullYear() - 1;
 
     const headers = {
       Authorization: `Bearer ${token}`,
       "Content-Type": "application/json",
     };
 
-    // GraphQL — contributions + recent activity
     const graphqlQuery = `
-      query($username: String!, $from: DateTime!, $to: DateTime!) {
+      query($username: String!) {
         user(login: $username) {
-          contributionsCollection(from: $from, to: $to) {
+          contributionsCollection {
             contributionCalendar {
               totalContributions
+              weeks {
+                contributionDays {
+                  date
+                  contributionCount
+                  color
+                }
+              }
             }
           }
           activity: contributionsCollection {
@@ -55,18 +60,13 @@ export const handler = async () => {
       }
     `;
 
-    // REST — total commit count + recent portfolio commits (parallel)
     const [graphqlRes, totalCommitsRes, recentCommitsRes] = await Promise.all([
       fetch("https://api.github.com/graphql", {
         method: "POST",
         headers,
         body: JSON.stringify({
           query: graphqlQuery,
-          variables: {
-            username,
-            from: `${year}-01-01T00:00:00Z`,
-            to: `${year}-12-31T23:59:59Z`,
-          },
+          variables: { username },
         }),
       }),
       fetch(`https://api.github.com/search/commits?q=author:${username}&per_page=1`, {
@@ -89,14 +89,14 @@ export const handler = async () => {
       return response(500, { error: graphqlResult.errors[0].message });
     }
 
-    const contributions =
-      graphqlResult.data?.user?.contributionsCollection.contributionCalendar.totalContributions ?? null;
+    const { totalContributions, weeks } =
+      graphqlResult.data?.user?.contributionsCollection.contributionCalendar ?? {};
 
     const totalCommits = totalCommitsResult.total_count ?? null;
 
     const recentPortfolioCommits = recentCommitsResult.map((c) => ({
       id: c.sha.slice(0, 7),
-      message: c.commit.message.split("\n")[0], // first line only
+      message: c.commit.message.split("\n")[0],
       date: c.commit.author.date,
       url: c.html_url,
     }));
@@ -108,7 +108,7 @@ export const handler = async () => {
       commitCount: r.contributions.nodes[0]?.commitCount ?? null,
     })) ?? [];
 
-    statsCache = { contributions, totalCommits };
+    statsCache = { contributions: totalContributions ?? null, weeks: weeks ?? [], totalCommits };
     statsCacheTime = now;
 
     activityCache = { recentPortfolioCommits, recentActivity };

--- a/src/components/sections/Projects.tsx
+++ b/src/components/sections/Projects.tsx
@@ -104,18 +104,26 @@ export default function Projects() {
                           e.preventDefault();
                           const current = portfolioEasterEggMessages[easterEggIndex];
                           if (current.type === "action") {
-                            toast(<span className="font-sans italic text-sm text-zinc-400 dark:text-zinc-500">{current.text}</span>);
+                            toast(
+                              <span className="font-sans italic text-sm text-zinc-400 dark:text-zinc-500">
+                                {current.text}
+                              </span>
+                            );
                             setEasterEggDisabled(true);
                             return;
                           }
-                          toast(<span className="font-sans text-sm">{current.text}</span>);
+                          toast(
+                            <span className="font-sans text-sm">
+                              {current.text}
+                            </span>
+                          );
                           setEasterEggIndex((prev) => prev + 1);
                         }
                       }}
                       className={
                         easterEggDisabled && project.title === "Personal Portfolio"
-                          ? "text-zinc-300 dark:text-zinc-700 pointer-events-none"
-                          : "text-zinc-400 dark:text-zinc-500 hover:text-zinc-600 dark:hover:text-zinc-400 transition-colors"
+                          ? "text-zinc-400 dark:text-zinc-500 hover:text-zinc-500 dark:hover:text-zinc-400 transition-colors pointer-events-none"
+                          : "text-zinc-400 dark:text-zinc-500 hover:text-zinc-500 dark:hover:text-zinc-400 transition-colors"
                       }
                     >
                       {easterEggDisabled && project.title === "Personal Portfolio"
@@ -128,7 +136,10 @@ export default function Projects() {
                 {project.repo && (
                   <Tooltip content="View repository" disabled={isMobile}>
                     <a href={project.repo} target="_blank" rel="noopener noreferrer"
-                      className="text-zinc-400 dark:text-zinc-500 hover:text-zinc-600 dark:hover:text-zinc-400 transition-colors">
+                      className="transition-colors
+                        text-zinc-400 dark:text-zinc-500 
+                        hover:text-zinc-500 dark:hover:text-zinc-400"
+                      >
                       <FaGithub size={16} className="overflow-clip" />
                     </a>
                   </Tooltip>

--- a/src/components/sections/Stats.tsx
+++ b/src/components/sections/Stats.tsx
@@ -1,16 +1,18 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import { IconMapPin, IconCode, IconClock, IconCalendarEvent, IconKeyboard, IconMusic } from "@tabler/icons-react";
+import { IconMapPin, IconCode, IconClock, IconCalendarEvent, IconKeyboard, IconVolume } from "@tabler/icons-react";
 
 import { profileInfo } from "@/lib/site";
 import SectionTitle from "@/components/sections/common/SectionTitle";
 import { getAge, getDaysUntilBirthday, getLocalTime } from "@/lib/utils/profile";
 import { fetchGithubData } from "@/lib/utils/github";
+import type { Week } from "@/lib/utils/github";
 import Skeleton from "@/components/ui/Skeleton";
 import AnimateText from "@/components/ui/AnimatedText";
 import useTextMarquee from "@/hooks/animations/useTextMarquee";
 import Tooltip from "@/components/ui/Tooltip";
+import ContributionGraph from "@/components/sections/common/ContributionGraph";
 
 const TIMEZONE = "Asia/Manila";
 const COUNTRY = "Philippines";
@@ -119,7 +121,7 @@ function StatItem({ stat }: { stat: StatItemType }) {
 export default function Stats() {
   const [age, setAge] = useState("—");
   const [time, setTime] = useState<{ time: string; offset: string } | null>(null);
-  const [githubStats, setGithubStats] = useState<{ contributions: number; totalCommits: number } | null>(null);
+  const [githubStats, setGithubStats] = useState<{ contributions: number; totalCommits: number; weeks: Week[] } | null>(null);
   const [wakatimeStats, setWakatimeStats] = useState<{ today: number; weekly: number; monthly: number; yearly: number } | null>(null);
   const [spotifyStats, setSpotifyStats] = useState<MusicStats | null>(null);
   const [monkeytypeStats, setMonkeytypeStats] = useState<{ wpm: number; acc: number; consistency: number } | null>(null);
@@ -130,7 +132,9 @@ export default function Stats() {
       setTime(getLocalTime(TIMEZONE));
     }, 1000);
 
-    fetchGithubData().then((data) => setGithubStats(data ? { contributions: data.contributions, totalCommits: data.totalCommits } : null));
+    fetchGithubData().then((data) =>
+      setGithubStats(data ? { contributions: data.contributions, totalCommits: data.totalCommits, weeks: data.weeks ?? [] } : null)
+    );
     fetchWakatimeStats().then(setWakatimeStats);
     fetchSpotifyStats().then(setSpotifyStats);
     fetchMonkeytypeStats().then(setMonkeytypeStats);
@@ -150,12 +154,12 @@ export default function Stats() {
     {
       icon: <IconMapPin size={18} />,
       label: `Currently in ${COUNTRY}`,
-      sublabel: <><AnimateText words={[time?.time ?? "—"]} variant="slot" cursor="none" /> <span>({time?.offset})</span> </>,
+      sublabel: <><AnimateText words={[time?.time ?? "—"]} variant="slot" cursor="none" /> <span>({time?.offset})</span></>,
       ready: time !== null,
     },
     {
       icon: <IconCode size={18} />,
-      label: <><span className="font-mono">{githubStats?.contributions.toLocaleString()}</span> contributions</>,
+      label: <><span className="font-mono">{githubStats?.totalCommits.toLocaleString()}</span> total commits</>,
       sublabel: "On GitHub in the last year",
       ready: githubStats !== null,
     },
@@ -173,7 +177,7 @@ export default function Stats() {
       ready: monkeytypeStats !== null,
     },
     {
-      icon: <IconMusic size={18} />,
+      icon: <IconVolume size={18} />,
       label: nowOrLast
         ? <><a href={nowOrLast.url} target="_blank" rel="noopener noreferrer" className="underline">{nowOrLast.song}</a> by {nowOrLast.artist}</>
         : "-",
@@ -187,6 +191,12 @@ export default function Stats() {
     <section className="w-full">
       <div className="mx-auto flex flex-col gap-10 px-6 sm:px-10">
         <SectionTitle title="Stats" />
+        {githubStats && (
+          <ContributionGraph
+            weeks={githubStats.weeks}
+            totalContributions={githubStats.contributions}
+          />
+        )}
         <ul className="columns-1 gap-6 sm:columns-2 md:columns-3">
           {stats.map((stat, i) => (
             <StatItem key={i} stat={stat} />

--- a/src/components/sections/Stats.tsx
+++ b/src/components/sections/Stats.tsx
@@ -158,6 +158,15 @@ export default function Stats() {
       ready: time !== null,
     },
     {
+      icon: <IconVolume size={18} />,
+      label: nowOrLast
+        ? <><a href={nowOrLast.url} target="_blank" rel="noopener noreferrer" className="underline">{nowOrLast.song}</a> by {nowOrLast.artist}</>
+        : "-",
+      labelText: nowOrLast ? `${nowOrLast.song} by ${nowOrLast.artist}` : undefined,
+      sublabel: spotifyStats?.nowPlaying ? "Currently playing" : "Song recently listened to",
+      ready: spotifyStats !== null,
+    },
+    {
       icon: <IconCode size={18} />,
       label: <><span className="font-mono">{githubStats?.totalCommits.toLocaleString()}</span> total commits</>,
       sublabel: "On GitHub in the last year",
@@ -173,17 +182,8 @@ export default function Stats() {
       icon: <IconKeyboard size={20} />,
       label: monkeytypeStats ? <><span className="font-mono">{Math.floor(monkeytypeStats.wpm)}</span> words per minute</> : "-",
       labelText: monkeytypeStats ? `${monkeytypeStats.wpm} 60s typing speed` : undefined,
-      sublabel: "60s typing speed",
+      sublabel: "Record typing speed in 60s",
       ready: monkeytypeStats !== null,
-    },
-    {
-      icon: <IconVolume size={18} />,
-      label: nowOrLast
-        ? <><a href={nowOrLast.url} target="_blank" rel="noopener noreferrer" className="underline">{nowOrLast.song}</a> by {nowOrLast.artist}</>
-        : "-",
-      labelText: nowOrLast ? `${nowOrLast.song} by ${nowOrLast.artist}` : undefined,
-      sublabel: spotifyStats?.nowPlaying ? "Currently playing" : "Recently played",
-      ready: spotifyStats !== null,
     },
   ];
 
@@ -197,7 +197,7 @@ export default function Stats() {
             totalContributions={githubStats.contributions}
           />
         )}
-        <ul className="columns-1 gap-6 sm:columns-2 md:columns-3">
+        <ul className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3">
           {stats.map((stat, i) => (
             <StatItem key={i} stat={stat} />
           ))}

--- a/src/components/sections/common/ContributionGraph.tsx
+++ b/src/components/sections/common/ContributionGraph.tsx
@@ -1,0 +1,92 @@
+"use client";
+
+import { useTheme } from "next-themes";
+import Tooltip from "@/components/ui/Tooltip";
+import type { Week } from "@/lib/utils/github";
+import { useEffect, useRef } from "react";
+
+const PALETTE = {
+  light: {
+    empty: "#ebedf0",
+    low:   "#9be9a8",
+    mid:   "#40c463",
+    high:  "#30a14e",
+    max:   "#216e39",
+  },
+  dark: {
+    empty: "#161b22",
+    low:   "#0e4429",
+    mid:   "#006d32",
+    high:  "#26a641",
+    max:   "#39d353",
+  },
+};
+
+type Props = {
+  weeks: Week[];
+  totalContributions?: number;
+};
+
+function getColor(count: number, isDark: boolean): string {
+  const color = isDark ? PALETTE.dark : PALETTE.light;
+  if (count === 0) return color.empty;
+  if (count <= 10)  return color.low;
+  if (count <= 25)  return color.mid;
+  if (count <= 40)  return color.high;
+  return color.max;
+}
+
+export default function ContributionGraph({ weeks, totalContributions }: Props) {
+  const { resolvedTheme } = useTheme();
+  const isDark = resolvedTheme === "dark";
+  const color = isDark ? PALETTE.dark : PALETTE.light;
+  const scrollRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (scrollRef.current) {
+      scrollRef.current.scrollLeft = scrollRef.current.scrollWidth;
+    }
+  }, [weeks]);
+
+  return (
+    <div className="flex flex-col gap-1">
+      {/* Contribution Graph */}
+      <div ref={scrollRef} className="overflow-x-auto pb-2">
+        <div className="mx-auto w-fit">
+          <div className="flex gap-0.75">
+            {weeks.map((week, wi) => (
+              <div key={wi} className="flex flex-col gap-0.75">
+                {week.contributionDays.map((day) => (
+                  <Tooltip
+                    key={day.date}
+                    content={`${day.contributionCount} contributions on ${new Date(day.date).toLocaleDateString("en-US", { month: "short", day: "numeric", year: "numeric" })}`}
+                  >
+                    <div
+                      style={{ backgroundColor: getColor(day.contributionCount, isDark) }}
+                      className="h-3 w-3 rounded-xs"
+                    />
+                  </Tooltip>
+                ))}
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+
+      {/* Labels & Legend */}
+      <div className="px-1 flex items-center justify-between gap-x-8 text-xs text-zinc-500 dark:text-zinc-400">
+        <span className="truncate">{totalContributions?.toLocaleString() ?? 0} GitHub contributions in the last year</span>
+        <span className="flex items-center gap-0.75">
+          {[color.empty, color.low, color.mid, color.high, color.max].map((color, i) => (
+            <Tooltip
+              key={i}
+              content={`${i === 0 ? "0" : i * 10 + 1} to ${i === 4 ? "40+" : (i + 1) * 10} contributions`}
+            >
+              <div key={i} style={{ backgroundColor: color }} className="h-3 w-3 rounded-xs" />
+            </Tooltip>
+          ))}
+        </span>
+      </div>
+    </div>
+  );
+}

--- a/src/components/ui/Tooltip.tsx
+++ b/src/components/ui/Tooltip.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useRef, useCallback, useEffect } from "react";
+import { createPortal } from "react-dom";
 
 type Props = {
   content: string;
@@ -8,30 +9,23 @@ type Props = {
   children: React.ReactNode;
 };
 
-type Position = "top" | "bottom";
-
 export default function Tooltip({ content, disabled = false, children }: Props) {
   const [visible, setVisible] = useState(false);
-  const [position, setPosition] = useState<Position>("top");
+  const [coords, setCoords] = useState({ top: 0, left: 0, isTop: true });
   const triggerRef = useRef<HTMLDivElement>(null);
-  const [offsetX, setOffsetX] = useState(0);
+  const [mounted] = useState(() => typeof window !== "undefined");
 
   const updatePosition = useCallback(() => {
     const el = triggerRef.current;
     if (!el) return;
     const rect = el.getBoundingClientRect();
-    const spaceAbove = rect.top;
-    const spaceBelow = window.innerHeight - rect.bottom;
-    setPosition(spaceAbove >= spaceBelow ? "top" : "bottom");
+    const isTop = rect.top >= window.innerHeight - rect.bottom;
 
-    // Shift tooltip left if it would overflow the right edge
-    const tooltipMaxWidth = 320;
-    const rightEdge = rect.left + tooltipMaxWidth;
-    if (rightEdge > window.innerWidth) {
-      setOffsetX(window.innerWidth - rightEdge - 8);
-    } else {
-      setOffsetX(0);
-    }
+    setCoords({
+      top: isTop ? rect.top : rect.bottom,
+      left: Math.min(rect.left, window.innerWidth - 328),
+      isTop,
+    });
   }, []);
 
   const show = useCallback(() => {
@@ -58,14 +52,20 @@ export default function Tooltip({ content, disabled = false, children }: Props) 
       onBlur={hide}
     >
       {children}
-      {visible && (
+      {visible && mounted && createPortal(
         <div
           role="tooltip"
-          style={{ left: offsetX }}
-          className={`${position === "top" ? "bottom-full mb-2" : "top-full mt-2"} pointer-events-none absolute left-0 z-50 w-max max-w-xs rounded-md border border-zinc-200 dark:border-zinc-700 bg-zinc-100 dark:bg-zinc-900 px-2.5 py-1.5 text-xs text-zinc-800 dark:text-zinc-200 shadow-md`}
+          style={{
+            position: "fixed",
+            top: coords.isTop ? coords.top - 8 : coords.top + 8,
+            left: coords.left,
+            transform: coords.isTop ? "translateY(-100%)" : "translateY(0)",
+          }}
+          className="pointer-events-none z-50 w-max max-w-xs rounded-md border border-zinc-200 dark:border-zinc-700 bg-zinc-100 dark:bg-zinc-900 px-2.5 py-1.5 text-xs text-zinc-800 dark:text-zinc-200 shadow-md"
         >
           {content}
-        </div>
+        </div>,
+        document.body
       )}
     </div>
   );

--- a/src/lib/utils/github.ts
+++ b/src/lib/utils/github.ts
@@ -1,7 +1,17 @@
-type GithubData = {
+export type ContributionDay = {
+  date: string;
+  contributionCount: number;
+};
+
+export type Week = {
+  contributionDays: ContributionDay[];
+};
+
+export type GithubData = {
   contributions: number;
   totalCommits: number;
   recentCommit: { id: string; url: string; date: string };
+  weeks: Week[];
 };
 
 export async function fetchGithubData(): Promise<GithubData | null> {
@@ -19,6 +29,7 @@ export async function fetchGithubData(): Promise<GithubData | null> {
       contributions: result.contributions,
       totalCommits: result.totalCommits,
       recentCommit: { id: commit.id, url: commit.url, date: commit.date },
+      weeks: result.weeks ?? [],
     };
   } catch (error) {
     console.error("Network or Parsing Error:", error);


### PR DESCRIPTION
## What's Changed?

### What's New
* **GitHub Contribution Graph:** Fetch GitHub weekly data and implement a visual contribution graph within the Stats section, complete with hover tooltips for individual day data.

### Refactors & Improvements
* **Stats Organization:** Reorder the profile statistics in the Stats section for better data hierarchy.
* **UI Feedback:** Update the hover colors for project link icons to improve interactive feedback.