### PR TITLE
fix: CORS headers for localhost and preserve S3 stats folder on deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -35,7 +35,7 @@ jobs:
           aws-region: ap-southeast-1
 
       - name: Deploy to S3
-        run: aws s3 sync out/ s3://${{ secrets.S3_BUCKET_NAME }} --delete
+        run: aws s3 sync out/ s3://${{ secrets.S3_BUCKET_NAME }} --delete --exclude "stats/*"
 
       - name: Invalidate CloudFront cache
         run: aws cloudfront create-invalidation --distribution-id ${{ secrets.CLOUDFRONT_DISTRIBUTION_ID }} --paths "/*"

--- a/terraform/cloudfront.tf
+++ b/terraform/cloudfront.tf
@@ -22,6 +22,7 @@ resource "aws_cloudfront_distribution" "portfolio" {
     cached_methods         = ["GET", "HEAD"]
     target_origin_id       = "S3-${var.bucket_name}"
     viewer_protocol_policy = "redirect-to-https"
+    response_headers_policy_id = aws_cloudfront_response_headers_policy.cors.id
 
     forwarded_values {
       query_string = false
@@ -86,4 +87,22 @@ resource "aws_cloudfront_function" "rewrite_uri" {
       return request;
     }
   EOT
+}
+
+resource "aws_cloudfront_response_headers_policy" "cors" {
+  name = "${var.project_name}-cors-policy"
+
+  cors_config {
+    access_control_allow_origins {
+      items = local.cors_origins
+    }
+    access_control_allow_headers {
+      items = ["*"]
+    }
+    access_control_allow_methods {
+      items = ["GET", "HEAD"]
+    }
+    access_control_allow_credentials = false
+    origin_override                   = true
+  }
 }


### PR DESCRIPTION
## Changes

### Terraform
- Added CloudFront response headers policy with CORS support for all allowed origins, including `dev_origins` (e.g. `localhost`)
- Attached policy to the default cache behavior

### CI/CD
- Excluded `stats/` from S3 sync deletion to preserve Lambda-written JSON files