### PR TITLE
feat: Add initial projects automation workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,4 @@
-name: Build
+name: Build the App
 
 on:
   workflow_call:

--- a/.github/workflows/resolve.yml
+++ b/.github/workflows/resolve.yml
@@ -1,0 +1,42 @@
+name: Resolve Linked Issues
+
+on:
+  pull_request:
+    branches:
+      - main
+    types:
+      - closed
+
+jobs:
+  resolve:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    steps:
+      - name: Update Date Resolved field
+        env:
+          GH_TOKEN: ${{ secrets.GH_PAT }}
+          PROJECT_ID: ${{ vars.PROJECT_ID }}
+          DATE_FIELD_ID: ${{ vars.DATE_RESOLVED_FIELD_ID }}
+        run: |
+          PR_NUMBER=${{ github.event.pull_request.number }}
+          OWNER=${{ github.repository_owner }}
+          REPO=${{ github.event.repository.name }}
+
+          ISSUE_ITEM_IDS=$(curl -s -H "Authorization: bearer $GH_TOKEN" \
+            -H "Content-Type: application/json" \
+            -d "{\"query\": \"{ repository(owner: \\\"$OWNER\\\", name: \\\"$REPO\\\") { pullRequest(number: $PR_NUMBER) { closingIssuesReferences(first: 10) { nodes { projectItems(first: 1) { nodes { id } } } } } } }\"}" \
+            https://api.github.com/graphql | jq -r '.data.repository.pullRequest.closingIssuesReferences.nodes[].projectItems.nodes[0]?.id // empty')
+
+          if [ -z "$ISSUE_ITEM_IDS" ]; then
+            echo "No linked issues found. Skipping."
+            exit 0
+          fi
+
+          TODAY=$(echo "${{ github.event.pull_request.merged_at }}" | cut -c1-10)
+
+          while IFS= read -r ISSUE_ITEM_ID; do
+            curl -s -H "Authorization: bearer $GH_TOKEN" \
+              -H "Content-Type: application/json" \
+              -d "{\"query\": \"mutation { updateProjectV2ItemFieldValue(input: { projectId: \\\"$PROJECT_ID\\\" itemId: \\\"$ISSUE_ITEM_ID\\\" fieldId: \\\"$DATE_FIELD_ID\\\" value: { date: \\\"$TODAY\\\" } }) { projectV2Item { id } } }\"}" \
+              https://api.github.com/graphql
+          done <<< "$ISSUE_ITEM_IDS"

--- a/.github/workflows/track.yml
+++ b/.github/workflows/track.yml
@@ -1,0 +1,37 @@
+name: Track Issue Creation
+
+on:
+  issues:
+    types:
+      - opened
+
+jobs:
+  track:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Update Date Created field
+        env:
+          GH_TOKEN: ${{ secrets.GH_PAT }}
+          PROJECT_ID: ${{ vars.PROJECT_ID }}
+          DATE_CREATED_FIELD_ID: ${{ vars.DATE_CREATED_FIELD_ID }}
+        run: |
+          OWNER=${{ github.repository_owner }}
+          REPO=${{ github.event.repository.name }}
+          ISSUE_NUMBER=${{ github.event.issue.number }}
+
+          ISSUE_ITEM_ID=$(curl -s -H "Authorization: bearer $GH_TOKEN" \
+            -H "Content-Type: application/json" \
+            -d "{\"query\": \"{ repository(owner: \\\"$OWNER\\\", name: \\\"$REPO\\\") { issue(number: $ISSUE_NUMBER) { projectItems(first: 1) { nodes { id } } } } }\"}" \
+            https://api.github.com/graphql | jq -r '.data.repository.issue.projectItems.nodes[0]?.id // empty')
+
+          if [ -z "$ISSUE_ITEM_ID" ] || [ "$ISSUE_ITEM_ID" = "null" ]; then
+            echo "Issue not in project. Skipping."
+            exit 0
+          fi
+
+          CREATED_AT=$(echo "${{ github.event.issue.created_at }}" | cut -c1-10)
+
+          curl -s -H "Authorization: bearer $GH_TOKEN" \
+            -H "Content-Type: application/json" \
+            -d "{\"query\": \"mutation { updateProjectV2ItemFieldValue(input: { projectId: \\\"$PROJECT_ID\\\" itemId: \\\"$ISSUE_ITEM_ID\\\" fieldId: \\\"$DATE_CREATED_FIELD_ID\\\" value: { date: \\\"$CREATED_AT\\\" } }) { projectV2Item { id } } }\"}" \
+            https://api.github.com/graphql

--- a/README.md
+++ b/README.md
@@ -52,7 +52,8 @@ luisabhram.dev/
 │   │   ├── build.yml                     # Reusable build workflow
 │   │   ├── check.yml                     # PR validation workflow
 │   │   ├── deploy.yml                    # GitHub Actions deployment workflow
-│   │   └── resolve.yml                   # Resolves linked issues on merge
+│   │   ├── resolve.yml                   # Updates fields of linked issues on merge
+│   │   └── track.yml                     # Updates fields from created issues
 │   └── dependabot.yml                    # Dependabot for automatic dependency updates
 ├── lambda/
 │   ├── spotify/
@@ -252,6 +253,7 @@ Ensure the following are configured in **Settings → Secrets and Variables → 
 | Name | Description |
 |---|---|
 | `PROJECT_ID` | GitHub Projects node ID |
+| `DATE_CREATED_FIELD_ID` | "Date Created" field node ID in GitHub Projects |
 | `DATE_RESOLVED_FIELD_ID` | "Date Resolved" field node ID in GitHub Projects |
 | `NEXT_PUBLIC_SITE_MODE` | Controls which page is displayed (`live`, `coming_soon`, `maintenance`) |
 | `NEXT_PUBLIC_GA_ID` | Google Analytics Measurement ID |

--- a/README.md
+++ b/README.md
@@ -50,8 +50,9 @@ luisabhram.dev/
 ├── .github/
 │   ├── workflows/
 │   │   ├── build.yml                     # Reusable build workflow
+│   │   ├── check.yml                     # PR validation workflow
 │   │   ├── deploy.yml                    # GitHub Actions deployment workflow
-│   │   └── check.yml                     # PR validation workflow
+│   │   └── resolve.yml                   # Resolves linked issues on merge
 │   └── dependabot.yml                    # Dependabot for automatic dependency updates
 ├── lambda/
 │   ├── spotify/
@@ -240,6 +241,7 @@ Ensure the following are configured in **Settings → Secrets and Variables → 
 **Secrets**
 | Name | Description |
 |---|---|
+| `GH_PAT` | GitHub Personal Access Token with relevant scopes |
 | `AWS_ACCESS_KEY_ID` | IAM user access key |
 | `AWS_SECRET_ACCESS_KEY` | IAM user secret key |
 | `CLOUDFRONT_DISTRIBUTION_ID` | CloudFront distribution ID |
@@ -249,6 +251,8 @@ Ensure the following are configured in **Settings → Secrets and Variables → 
 **Variables**
 | Name | Description |
 |---|---|
+| `PROJECT_ID` | GitHub Projects node ID |
+| `DATE_RESOLVED_FIELD_ID` | "Date Resolved" field node ID in GitHub Projects |
 | `NEXT_PUBLIC_SITE_MODE` | Controls which page is displayed (`live`, `coming_soon`, `maintenance`) |
 | `NEXT_PUBLIC_GA_ID` | Google Analytics Measurement ID |
 | `NEXT_PUBLIC_SENTRY_DSN` | Sentry DSN for error monitoring |
@@ -268,7 +272,7 @@ Ensure the following are configured in **Settings → Secrets and Variables → 
 3. Downloads the `/out` artifact in the deploy job
 4. Syncs `/out` to S3, preserving the `stats/` folder managed by Lambda
 5. Invalidates the CloudFront cache
-6. Changes are live at [luisabhram.dev](https://luisabhram.dev)
+6. Updates the "Date Resolved" field on any linked GitHub Projects issue
 
 ---
 

--- a/src/lib/site.ts
+++ b/src/lib/site.ts
@@ -75,7 +75,7 @@ export const profileInfo = {
       start: "Mar 2024",
       end: "Jun 2024",
       about: "Third Generation Holdings is a Filipino conglomerate with business interests in security, manpower, and facilities management.",
-      scope: "Served as an intern software developer, building a forms and time log app for the security and roving team.",
+      scope: "Served as an intern software developer, building the company's forms/reporting app for automated data collection, and data visualization.",
     },
     {
       company: "Gingersnaps PH",


### PR DESCRIPTION
## Summary
Mainly adds two GitHub Actions workflows to automate field updates in GitHub Projects.

## Changes

### `resolve.yml`
- Triggers when a PR is merged to `main`. Finds all linked issues (via `closes #`) and sets their **Date Resolved** field to the PR's merge date. Resolves #101 

### `track.yml`
- Triggers when an issue is opened in the repo. Sets the **Date Created** field to the issue's creation date if it's already in the project. Resolves #102 

## New Secrets & Variables
| Name | Type | Description |
|---|---|---|
| `GH_PAT` | Secret | Personal Access Token with `repo` and `project` scopes |
| `PROJECT_ID` | Variable | GitHub Projects node ID |
| `DATE_RESOLVED_FIELD_ID` | Variable | "Date Resolved" field node ID |
| `DATE_CREATED_FIELD_ID` | Variable | "Date Created" field node ID |