### PR TITLE
fix: Update Intro layering and reduce Spotify polling interval

### DIFF
--- a/.github/workflows/resolve.yml
+++ b/.github/workflows/resolve.yml
@@ -12,7 +12,7 @@ jobs:
     if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     steps:
-      - name: Update Date Resolved field
+      - name: Update date resolved field
         env:
           GH_TOKEN: ${{ secrets.GH_PAT }}
           PROJECT_ID: ${{ vars.PROJECT_ID }}

--- a/.github/workflows/track.yml
+++ b/.github/workflows/track.yml
@@ -9,7 +9,7 @@ jobs:
   track:
     runs-on: ubuntu-latest
     steps:
-      - name: Update Date Created field
+      - name: Update date created field
         env:
           GH_TOKEN: ${{ secrets.GH_PAT }}
           PROJECT_ID: ${{ vars.PROJECT_ID }}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -12,9 +12,9 @@ export default function Home() {
   return (
     <PageAnimator>
       <div className="mx-auto max-w-4xl w-full flex flex-1 flex-col font-sans py-18 sm:py-18 gap-28">
-        <div className="min-h-[calc(100svh-4rem)] flex flex-col justify-center gap-28 sm:-mt-6 sm:-mb-20">
+        <div className="xl:min-h-[calc(100svh-4rem)] flex flex-col justify-center gap-28 sm:-mt-6 xl:-mb-20">
           {/* Intro, Tagline, Profile */}
-          <AnimatedSection className="mt-24 sm:mt-0">
+          <AnimatedSection className="mt-24 xl:mt-0">
             <Intro />
           </AnimatedSection>
 

--- a/src/components/sections/Stats.tsx
+++ b/src/components/sections/Stats.tsx
@@ -16,7 +16,7 @@ import ContributionGraph from "@/components/sections/common/ContributionGraph";
 
 const TIMEZONE = "Asia/Manila";
 const COUNTRY = "Philippines";
-const SONG_REFRESH_INTERVAL = 2.5; // 2 min 30 sec
+const SONG_REFRESH_INTERVAL = 1.5; // 1 min 30 sec
 const LOADMS_CONTRIBUTION_GRAPH = 1400;
 
 async function fetchWakatimeStats(): Promise<{ today: number; weekly: number; monthly: number; yearly: number } | null> {


### PR DESCRIPTION
## What's Changed?

### Fixes
* **Layout Layering:** Fix the Intro section stacking order to prevent it from sliding behind the header background on small to medium screen sizes. Fixes #104 

### Refactors & Improvements
* **Spotify Polling:** Reduce the Spotify "now playing" refresh interval from 2.5 minutes to 1.5 minutes to provide more frequent status updates in the Stats section.

### Maintenance
* **CI/CD Consistency:** Standardize capitalization across all workflow step names to maintain a clean and consistent CI environment.