### PR TITLE
chore: Improve dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -24,3 +24,7 @@ updates:
       prefix: "chore"
     labels:
       - "dependencies"
+    groups:
+      dependencies:
+        patterns:
+          - "*"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,6 +3,7 @@ version: 2
 updates:
   - package-ecosystem: "npm"
     directory: "/"
+    target-branch: "dev"
     schedule:
       interval: "weekly"
     commit-message:
@@ -16,6 +17,7 @@ updates:
 
   - package-ecosystem: "github-actions"
     directory: "/"
+    target-branch: "dev"
     schedule:
       interval: "weekly"
     commit-message:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,8 @@ updates:
       interval: "weekly"
     commit-message:
       prefix: "chore"
+    labels:
+      - "dependencies"
     groups:
       dependencies:
         patterns:
@@ -18,3 +20,5 @@ updates:
       interval: "weekly"
     commit-message:
       prefix: "chore"
+    labels:
+      - "dependencies"

--- a/src/lib/site.ts
+++ b/src/lib/site.ts
@@ -20,7 +20,7 @@ export const profileInfo = {
   birthDate: "2003/03/26",
   image: "/avatar.png",
   emails: [
-    "work.luisabhram@gmail.com"
+    "contact@luisabhram.dev"
   ],
   socialLinks: [
     { label: "GitHub", link: "https://github.com/cymophic" },


### PR DESCRIPTION
**What's Changed:**

- Configure dependabot to use custom `dependencies` label. Fixes #112 
- Set `target-branch` to `dev` for npm and github-actions updates
- Add `groups` section to github-actions to consolidate PRs