### PR TITLE
fix: Correct theme transition origin on mobile by accounting for `visualViewport` offset

### DIFF
--- a/src/hooks/animations/useThemeTransition.ts
+++ b/src/hooks/animations/useThemeTransition.ts
@@ -19,7 +19,7 @@ export function useThemeTransition(isDark: boolean): UseThemeTransitionResult {
 
     const rect = button.getBoundingClientRect();
     const x = rect.left + rect.width / 2;
-    const y = rect.top + rect.height / 2;
+    const y = rect.top + rect.height / 2 + (window.visualViewport?.offsetTop ?? 0);
     const endRadius = Math.hypot(
       Math.max(x, window.innerWidth - x),
       Math.max(y, window.innerHeight - y)


### PR DESCRIPTION
- Resolves #122 