### PR TITLE
fix: Resolve subpage 404s on CloudFront static export

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -3,6 +3,7 @@ import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
   output: "export",
+  trailingSlash: true,
   images: {
     unoptimized: true,
     remotePatterns: [


### PR DESCRIPTION
## What's Changed?

Adds `trailingSlash: true` to `next.config.ts` so Next.js generates `projects/index.html` instead of `projects.html` on static export, matching the `/index.html` rewrite pattern expected by the CloudFront `viewer-request` function.