### PR TITLE
fix: Client-side navigator access and metadata formatting

### DIFF
--- a/src/components/layout/footer/Metadata.tsx
+++ b/src/components/layout/footer/Metadata.tsx
@@ -26,7 +26,7 @@ export default function Metadata() {
       content: latestCommit?.id ?? "-",
       icon: IconGitCommit,
     },
-    { label: "Last Updated", content: lastUpdated },
+    { label: "Last Updated", content: lastUpdated.toLowerCase() },
   ];
 
   return (

--- a/src/hooks/utils/useMetadata.ts
+++ b/src/hooks/utils/useMetadata.ts
@@ -50,7 +50,13 @@ export function useVisitCount() {
 
 // Detects and returns the visitor's operating system on mount
 export function useDeviceOS() {
-  const [os] = useState(() => getDeviceOS());
+  const [os, setOs] = useState("—");
+
+  useEffect(() => {
+    /* eslint-disable-next-line react-hooks/set-state-in-effect -- one-time client-side initialization */
+    setOs(getDeviceOS());
+  }, []);
+
   return os;
 }
 


### PR DESCRIPTION
## What's Changed?

### Fixes
* **Client-Side Execution:** Wrapped the `navigator` access within a `useEffect` hook.
* **Metadata Formatting:** Updated the "Commit Date" metadata string to use lowercase characters for visual consistency with the rest of the metadata's UI elements.