### PR TITLE
perf: Optimize page loading and refine project components

### DIFF
--- a/src/app/(main)/projects/page.tsx
+++ b/src/app/(main)/projects/page.tsx
@@ -28,7 +28,7 @@ export default function Projects() {
         <div className="columns-1 sm:columns-2 xl:columns-3 gap-6">
           {projects.map((project, i) => (
             <AnimatedSection key={i} className="break-inside-avoid mb-6">
-              <ProjectCard project={project} />
+              <ProjectCard project={project} priority={i === 0} />
             </AnimatedSection>
           ))}
         </div>

--- a/src/app/(main)/projects/page.tsx
+++ b/src/app/(main)/projects/page.tsx
@@ -1,7 +1,6 @@
 import { projects } from "@/lib/site";
 import ProjectCard from "@/components/ui/ProjectCard";
 import { AnimatedSection } from "@/components/ui/PageAnimator";
-import TechStack from "@/components/sections/home/TechStack";
 
 export default function Projects() {
   return (
@@ -17,11 +16,6 @@ export default function Projects() {
             side-projects to full-scale production systems for enterprise
             companies.
           </p>
-        </AnimatedSection>
-
-        {/* Tech Stack */}
-        <AnimatedSection className="-my-16 sm:-my-12">
-          <TechStack />
         </AnimatedSection>
 
         {/* Projects */}

--- a/src/components/sections/home/Intro.tsx
+++ b/src/components/sections/home/Intro.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState, useRef } from "react";
+import { useState, useRef } from "react";
 import { getCalApi } from "@calcom/embed-react";
 import { IconQuoteOpen, IconBriefcase, IconMapPin } from "@tabler/icons-react";
 
@@ -77,29 +77,31 @@ export function Location() {
 // Schedule Button
 export function ScheduleButton() {
   const [bookingDisabled, setBookingDisabled] = useState(false);
+  const calLoaded = useRef(false);
 
-  useEffect(() => {
-    (async function () {
-      const cal = await getCalApi({ namespace: "book-a-meeting" });
-      cal("ui", {
-        hideEventTypeDetails: false,
-      });
-      cal("on", {
-        action: "bookingSuccessful",
-        callback: () => setBookingDisabled(true),
-      });
-    })();
-  }, []);
+  const loadCal = async () => {
+    if (calLoaded.current) return;
+    calLoaded.current = true;
+    const cal = await getCalApi({ namespace: "book-a-meeting" });
+    cal("ui", { hideEventTypeDetails: false });
+    cal("on", {
+      action: "bookingSuccessful",
+      callback: () => setBookingDisabled(true),
+    });
+  };
 
   return (
     <Button
       variant="primary"
       size="md"
       className="sm:mt-0 mx-auto rounded-lg w-full max-w-94 sm:w-54 sm:h-11 sm:px-4 sm:text-sm whitespace-nowrap active:scale-93 transition-transform duration-70"
-      disabled={bookingDisabled}
       data-cal-namespace="book-a-meeting"
       data-cal-link="luisabhram"
       data-cal-config='{"layout":"month_view"}'
+      onMouseEnter={loadCal}
+      onFocus={loadCal}
+      onClick={loadCal}
+      disabled={bookingDisabled}
     >
       {bookingDisabled ? "Meeting Scheduled" : "Schedule a Meeting"}
     </Button>

--- a/src/components/ui/ProjectCard.tsx
+++ b/src/components/ui/ProjectCard.tsx
@@ -21,10 +21,12 @@ const tagPillClass =
 
 export default function ProjectCard({
   project,
-  showImage = true,
+  showImage,
+  priority,
 }: {
   project: Project;
   showImage?: boolean;
+  priority?: boolean;
 }) {
   const router = useRouter();
 
@@ -43,6 +45,7 @@ export default function ProjectCard({
         <div className="hidden sm:block">
           <Image
             src={project.cover}
+            priority={priority}
             alt={`${project.title} cover`}
             width={800}
             height={450}

--- a/src/components/ui/ProjectCard.tsx
+++ b/src/components/ui/ProjectCard.tsx
@@ -21,7 +21,7 @@ const tagPillClass =
 
 export default function ProjectCard({
   project,
-  showImage,
+  showImage=true,
   priority,
 }: {
   project: Project;


### PR DESCRIPTION
## What's Changed?

### Performance & Optimization
* **Lazy Loading:** Implemented lazy loading for the `Cal.com` embed. The component now only loads upon user interaction with the trigger button, significantly reducing the initial page weight.
* **LCP Improvement:** Added the `priority` attribute to the Largest Contentful Paint (LCP) image on the projects page to speed up the critical rendering path.

### Refactors & Improvements
* **Cleanup:** Removed the `TechStack` component from the Projects page to streamline the interface and reduce redundant information.

### Fixes
* **Component Defaults:** Set the default value of the `showImage` prop in `ProjectCard` to `true`, ensuring project thumbnails display correctly by default unless explicitly disabled.