### PR TITLE
feat: add markdown project pages, rewrite narratives, show yearly stats

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,8 @@
         "next": "^16.2.6",
         "react": "^19.2.6",
         "react-dom": "^19.2.6",
+        "react-markdown": "^10.1.0",
+        "remark-gfm": "^4.0.1",
         "sonner": "^2.0.7"
       },
       "devDependencies": {
@@ -2052,6 +2054,15 @@
         "tslib": "^2.4.0"
       }
     },
+    "node_modules/@types/debug": {
+      "version": "4.1.13",
+      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.13.tgz",
+      "integrity": "sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/ms": "*"
+      }
+    },
     "node_modules/@types/esrecurse": {
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/@types/esrecurse/-/esrecurse-4.3.1.tgz",
@@ -2062,8 +2073,25 @@
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
-      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
-      "dev": true
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w=="
+    },
+    "node_modules/@types/estree-jsx": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@types/estree-jsx/-/estree-jsx-1.0.5.tgz",
+      "integrity": "sha512-52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "*"
+      }
+    },
+    "node_modules/@types/hast": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.5.tgz",
+      "integrity": "sha512-rp/ezSWaD1m44dPKICGhiskI13nVr7qTloFwDa/IYkhhf5nzwP+zIQcIJh3WIFSBOy/H1PzB40jPjMDksN4F+g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
     },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
@@ -2077,6 +2105,21 @@
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
       "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/mdast": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.4.tgz",
+      "integrity": "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
+    "node_modules/@types/ms": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
+      "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
       "license": "MIT"
     },
     "node_modules/@types/node": {
@@ -2093,7 +2136,6 @@
       "version": "19.2.15",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.15.tgz",
       "integrity": "sha512-eRwcGNHve+E8qtEQSSRl6urh+rFop4v8gm6O8rGv25CodbvFdLjA1vVQ1KkiFE0w0UPOnb8tDiFKL5lp0rtY5Q==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
@@ -2107,6 +2149,12 @@
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
+    },
+    "node_modules/@types/unist": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
+      "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
+      "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.58.0",
@@ -2338,6 +2386,12 @@
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
       }
+    },
+    "node_modules/@ungap/structured-clone": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.3.tgz",
+      "integrity": "sha512-60YRaenCQcVjYEKOcG824+DRGGIQ3VKErcBoAEDJZz5bKIs2ZG+X/H9Nk+Q6EVkwJk5QNApxbrc5QtBSwtrXAg==",
+      "license": "ISC"
     },
     "node_modules/@unrs/resolver-binding-android-arm-eabi": {
       "version": "1.11.1",
@@ -2881,6 +2935,16 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/bail": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/bail/-/bail-2.0.2.tgz",
+      "integrity": "sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/balanced-match": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
@@ -3028,10 +3092,70 @@
         }
       ]
     },
+    "node_modules/ccount": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/ccount/-/ccount-2.0.1.tgz",
+      "integrity": "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-entities": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-2.0.2.tgz",
+      "integrity": "sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-entities-html4": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/character-entities-html4/-/character-entities-html4-2.1.0.tgz",
+      "integrity": "sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-entities-legacy": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-3.0.0.tgz",
+      "integrity": "sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-reference-invalid": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/character-reference-invalid/-/character-reference-invalid-2.0.1.tgz",
+      "integrity": "sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/client-only": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
       "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA=="
+    },
+    "node_modules/comma-separated-tokens": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-2.0.3.tgz",
+      "integrity": "sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
     },
     "node_modules/concat-map": {
       "version": "0.0.1",
@@ -3064,8 +3188,7 @@
     "node_modules/csstype": {
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
-      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "dev": true
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ=="
     },
     "node_modules/damerau-levenshtein": {
       "version": "1.0.8",
@@ -3129,7 +3252,6 @@
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "dev": true,
       "dependencies": {
         "ms": "^2.1.3"
       },
@@ -3140,6 +3262,19 @@
         "supports-color": {
           "optional": true
         }
+      }
+    },
+    "node_modules/decode-named-character-reference": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/decode-named-character-reference/-/decode-named-character-reference-1.3.0.tgz",
+      "integrity": "sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==",
+      "license": "MIT",
+      "dependencies": {
+        "character-entities": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/deep-is": {
@@ -3182,6 +3317,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/detect-libc": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
@@ -3189,6 +3333,19 @@
       "devOptional": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/devlop": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/devlop/-/devlop-1.1.0.tgz",
+      "integrity": "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==",
+      "license": "MIT",
+      "dependencies": {
+        "dequal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/doctrine": {
@@ -3900,6 +4057,16 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/estree-util-is-identifier-name": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/estree-util-is-identifier-name/-/estree-util-is-identifier-name-3.0.0.tgz",
+      "integrity": "sha512-hFtqIDZTIUZ9BXLb8y4pYGyk6+wekIivNVTcmvk8NoOh+VeRn5y6cEHzbURrWbfp1fIqdVipilzj+lfaadNZmg==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -3908,6 +4075,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "license": "MIT"
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
@@ -4312,6 +4485,46 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/hast-util-to-jsx-runtime": {
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/hast-util-to-jsx-runtime/-/hast-util-to-jsx-runtime-2.3.6.tgz",
+      "integrity": "sha512-zl6s8LwNyo1P9uw+XJGvZtdFF1GdAkOg8ujOw+4Pyb76874fLps4ueHXDhXWdk6YHQ6OgUtinliG7RsYvCbbBg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/unist": "^3.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "devlop": "^1.0.0",
+        "estree-util-is-identifier-name": "^3.0.0",
+        "hast-util-whitespace": "^3.0.0",
+        "mdast-util-mdx-expression": "^2.0.0",
+        "mdast-util-mdx-jsx": "^3.0.0",
+        "mdast-util-mdxjs-esm": "^2.0.0",
+        "property-information": "^7.0.0",
+        "space-separated-tokens": "^2.0.0",
+        "style-to-js": "^1.0.0",
+        "unist-util-position": "^5.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-whitespace": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-whitespace/-/hast-util-whitespace-3.0.0.tgz",
+      "integrity": "sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/hermes-estree": {
       "version": "0.25.1",
       "resolved": "https://registry.npmjs.org/hermes-estree/-/hermes-estree-0.25.1.tgz",
@@ -4327,6 +4540,16 @@
       "license": "MIT",
       "dependencies": {
         "hermes-estree": "0.25.1"
+      }
+    },
+    "node_modules/html-url-attributes": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/html-url-attributes/-/html-url-attributes-3.0.1.tgz",
+      "integrity": "sha512-ol6UPyBWqsrO6EJySPz2O7ZSr856WDrEzM5zMqp+FJJLGMW35cLYmmZnl0vztAZxRUoNZJFTCohfjuIJ8I4QBQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/ignore": {
@@ -4348,6 +4571,12 @@
         "node": ">=0.8.19"
       }
     },
+    "node_modules/inline-style-parser": {
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/inline-style-parser/-/inline-style-parser-0.2.7.tgz",
+      "integrity": "sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==",
+      "license": "MIT"
+    },
     "node_modules/internal-slot": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.1.0.tgz",
@@ -4360,6 +4589,30 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/is-alphabetical": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-alphabetical/-/is-alphabetical-2.0.1.tgz",
+      "integrity": "sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/is-alphanumerical": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-alphanumerical/-/is-alphanumerical-2.0.1.tgz",
+      "integrity": "sha512-hmbYhX/9MUMF5uh7tOXyK/n0ZvWpad5caBA17GsC6vyuCqaWliRG5K1qS9inmUhEMaOBIW7/whAnSwveW/LtZw==",
+      "license": "MIT",
+      "dependencies": {
+        "is-alphabetical": "^2.0.0",
+        "is-decimal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/is-array-buffer": {
@@ -4512,6 +4765,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-decimal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-decimal/-/is-decimal-2.0.1.tgz",
+      "integrity": "sha512-AAB9hiomQs5DXWcRB1rqsxGUstbRroFOPPVAomNk/3XHR5JyEZChOyTWe2oayKnsSsr/kcGqF+z6yuH6HHpN0A==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -4567,6 +4830,16 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-hexadecimal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-hexadecimal/-/is-hexadecimal-2.0.1.tgz",
+      "integrity": "sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/is-map": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/is-map/-/is-map-2.0.3.tgz",
@@ -4615,6 +4888,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-plain-obj": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
+      "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-regex": {
@@ -5176,6 +5461,16 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/longest-streak": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/longest-streak/-/longest-streak-3.1.0.tgz",
+      "integrity": "sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/loose-envify": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
@@ -5209,6 +5504,16 @@
         "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
+    "node_modules/markdown-table": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-3.0.4.tgz",
+      "integrity": "sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -5216,6 +5521,288 @@
       "dev": true,
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/mdast-util-find-and-replace": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mdast-util-find-and-replace/-/mdast-util-find-and-replace-3.0.2.tgz",
+      "integrity": "sha512-Tmd1Vg/m3Xz43afeNxDIhWRtFZgM2VLyaf4vSTYwudTyeuTneoL3qtWMA5jeLyz/O1vDJmmV4QuScFCA2tBPwg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "escape-string-regexp": "^5.0.0",
+        "unist-util-is": "^6.0.0",
+        "unist-util-visit-parents": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-find-and-replace/node_modules/escape-string-regexp": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
+      "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mdast-util-from-markdown": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-2.0.3.tgz",
+      "integrity": "sha512-W4mAWTvSlKvf8L6J+VN9yLSqQ9AOAAvHuoDAmPkz4dHf553m5gVj2ejadHJhoJmcmxEnOv6Pa8XJhpxE93kb8Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-to-string": "^4.0.0",
+        "micromark": "^4.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-decode-string": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "unist-util-stringify-position": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm/-/mdast-util-gfm-3.1.0.tgz",
+      "integrity": "sha512-0ulfdQOM3ysHhCJ1p06l0b0VKlhU0wuQs3thxZQagjcjPrlFRqY215uZGHHJan9GEAXd9MbfPjFJz+qMkVR6zQ==",
+      "license": "MIT",
+      "dependencies": {
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-gfm-autolink-literal": "^2.0.0",
+        "mdast-util-gfm-footnote": "^2.0.0",
+        "mdast-util-gfm-strikethrough": "^2.0.0",
+        "mdast-util-gfm-table": "^2.0.0",
+        "mdast-util-gfm-task-list-item": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-autolink-literal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-autolink-literal/-/mdast-util-gfm-autolink-literal-2.0.1.tgz",
+      "integrity": "sha512-5HVP2MKaP6L+G6YaxPNjuL0BPrq9orG3TsrZ9YXbA3vDw/ACI4MEsnoDpn6ZNm7GnZgtAcONJyPhOP8tNJQavQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "ccount": "^2.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-find-and-replace": "^3.0.0",
+        "micromark-util-character": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-footnote": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-footnote/-/mdast-util-gfm-footnote-2.1.0.tgz",
+      "integrity": "sha512-sqpDWlsHn7Ac9GNZQMeUzPQSMzR6Wv0WKRNvQRg0KqHh02fpTz69Qc1QSseNX29bhz1ROIyNyxExfawVKTm1GQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.1.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-strikethrough": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-strikethrough/-/mdast-util-gfm-strikethrough-2.0.0.tgz",
+      "integrity": "sha512-mKKb915TF+OC5ptj5bJ7WFRPdYtuHv0yTRxK2tJvi+BDqbkiG7h7u/9SI89nRAYcmap2xHQL9D+QG/6wSrTtXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-table": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-table/-/mdast-util-gfm-table-2.0.0.tgz",
+      "integrity": "sha512-78UEvebzz/rJIxLvE7ZtDd/vIQ0RHv+3Mh5DR96p7cS7HsBhYIICDBCu8csTNWNO6tBWfqXPWekRuj2FNOGOZg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "markdown-table": "^3.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-task-list-item": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-task-list-item/-/mdast-util-gfm-task-list-item-2.0.0.tgz",
+      "integrity": "sha512-IrtvNvjxC1o06taBAVJznEnkiHxLFTzgonUdy8hzFVeDun0uTjxxrRGVaNFqkU1wJR3RBPEfsxmU6jDWPofrTQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-mdx-expression": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-mdx-expression/-/mdast-util-mdx-expression-2.0.1.tgz",
+      "integrity": "sha512-J6f+9hUp+ldTZqKRSg7Vw5V6MqjATc+3E4gf3CFNcuZNWD8XdyI6zQ8GqH7f8169MM6P7hMBRDVGnn7oHB9kXQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-mdx-jsx": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-mdx-jsx/-/mdast-util-mdx-jsx-3.2.0.tgz",
+      "integrity": "sha512-lj/z8v0r6ZtsN/cGNNtemmmfoLAFZnjMbNyLzBafjzikOM+glrjNHPlf6lQDOTccj9n5b0PPihEBbhneMyGs1Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "ccount": "^2.0.0",
+        "devlop": "^1.1.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "parse-entities": "^4.0.0",
+        "stringify-entities": "^4.0.0",
+        "unist-util-stringify-position": "^4.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-mdxjs-esm": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-mdxjs-esm/-/mdast-util-mdxjs-esm-2.0.1.tgz",
+      "integrity": "sha512-EcmOpxsZ96CvlP03NghtH1EsLtr0n9Tm4lPUJUBccV9RwUOneqSycg19n5HGzCf+10LozMRSObtVr3ee1WoHtg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-phrasing": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-phrasing/-/mdast-util-phrasing-4.1.0.tgz",
+      "integrity": "sha512-TqICwyvJJpBwvGAMZjj4J2n0X8QWp21b9l0o7eXyVJ25YNWYbJDVIyD1bZXE6WtV6RmKJVYmQAKWa0zWOABz2w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-hast": {
+      "version": "13.2.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-13.2.1.tgz",
+      "integrity": "sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "@ungap/structured-clone": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "trim-lines": "^3.0.0",
+        "unist-util-position": "^5.0.0",
+        "unist-util-visit": "^5.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-markdown": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-markdown/-/mdast-util-to-markdown-2.1.2.tgz",
+      "integrity": "sha512-xj68wMTvGXVOKonmog6LwyJKrYXZPvlwabaryTjLh9LuvovB/KAH+kvi8Gjj+7rJjsFi23nkUxRQv1KqSroMqA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "longest-streak": "^3.0.0",
+        "mdast-util-phrasing": "^4.0.0",
+        "mdast-util-to-string": "^4.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-decode-string": "^2.0.0",
+        "unist-util-visit": "^5.0.0",
+        "zwitch": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-4.0.0.tgz",
+      "integrity": "sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/merge2": {
@@ -5227,6 +5814,569 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/micromark": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/micromark/-/micromark-4.0.2.tgz",
+      "integrity": "sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@types/debug": "^4.0.0",
+        "debug": "^4.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-core-commonmark": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-combine-extensions": "^2.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-encode": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-subtokenize": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-core-commonmark": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/micromark-core-commonmark/-/micromark-core-commonmark-2.0.3.tgz",
+      "integrity": "sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-factory-destination": "^2.0.0",
+        "micromark-factory-label": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-factory-title": "^2.0.0",
+        "micromark-factory-whitespace": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-html-tag-name": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-subtokenize": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-extension-gfm": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm/-/micromark-extension-gfm-3.0.0.tgz",
+      "integrity": "sha512-vsKArQsicm7t0z2GugkCKtZehqUm31oeGBV/KVSorWSy8ZlNAv7ytjFhvaryUiCUJYqs+NoE6AFhpQvBTM6Q4w==",
+      "license": "MIT",
+      "dependencies": {
+        "micromark-extension-gfm-autolink-literal": "^2.0.0",
+        "micromark-extension-gfm-footnote": "^2.0.0",
+        "micromark-extension-gfm-strikethrough": "^2.0.0",
+        "micromark-extension-gfm-table": "^2.0.0",
+        "micromark-extension-gfm-tagfilter": "^2.0.0",
+        "micromark-extension-gfm-task-list-item": "^2.0.0",
+        "micromark-util-combine-extensions": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-autolink-literal": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-autolink-literal/-/micromark-extension-gfm-autolink-literal-2.1.0.tgz",
+      "integrity": "sha512-oOg7knzhicgQ3t4QCjCWgTmfNhvQbDDnJeVu9v81r7NltNCVmhPy1fJRX27pISafdjL+SVc4d3l48Gb6pbRypw==",
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-footnote": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-footnote/-/micromark-extension-gfm-footnote-2.1.0.tgz",
+      "integrity": "sha512-/yPhxI1ntnDNsiHtzLKYnE3vf9JZ6cAisqVDauhp4CEHxlb4uoOTxOCJ+9s51bIB8U1N1FJ1RXOKTIlD5B/gqw==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-core-commonmark": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-strikethrough": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-strikethrough/-/micromark-extension-gfm-strikethrough-2.1.0.tgz",
+      "integrity": "sha512-ADVjpOOkjz1hhkZLlBiYA9cR2Anf8F4HqZUO6e5eDcPQd0Txw5fxLzzxnEkSkfnD0wziSGiv7sYhk/ktvbf1uw==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-table": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-table/-/micromark-extension-gfm-table-2.1.1.tgz",
+      "integrity": "sha512-t2OU/dXXioARrC6yWfJ4hqB7rct14e8f7m0cbI5hUmDyyIlwv5vEtooptH8INkbLzOatzKuVbQmAYcbWoyz6Dg==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-tagfilter": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-tagfilter/-/micromark-extension-gfm-tagfilter-2.0.0.tgz",
+      "integrity": "sha512-xHlTOmuCSotIA8TW1mDIM6X2O1SiX5P9IuDtqGonFhEK0qgRI4yeC6vMxEV2dgyr2TiD+2PQ10o+cOhdVAcwfg==",
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-task-list-item": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-task-list-item/-/micromark-extension-gfm-task-list-item-2.1.0.tgz",
+      "integrity": "sha512-qIBZhqxqI6fjLDYFTBIa4eivDMnP+OZqsNwmQ3xNLE4Cxwc+zfQEfbs6tzAo2Hjq+bh6q5F+Z8/cksrLFYWQQw==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-factory-destination": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-destination/-/micromark-factory-destination-2.0.1.tgz",
+      "integrity": "sha512-Xe6rDdJlkmbFRExpTOmRj9N3MaWmbAgdpSrBQvCFqhezUn4AHqJHbaEnfbVYYiexVSs//tqOdY/DxhjdCiJnIA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-label": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-label/-/micromark-factory-label-2.0.1.tgz",
+      "integrity": "sha512-VFMekyQExqIW7xIChcXn4ok29YE3rnuyveW3wZQWWqF4Nv9Wk5rgJ99KzPvHjkmPXF93FXIbBp6YdW3t71/7Vg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-space": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-space/-/micromark-factory-space-2.0.1.tgz",
+      "integrity": "sha512-zRkxjtBxxLd2Sc0d+fbnEunsTj46SWXgXciZmHq0kDYGnck/ZSGj9/wULTV95uoeYiK5hRXP2mJ98Uo4cq/LQg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-title": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-title/-/micromark-factory-title-2.0.1.tgz",
+      "integrity": "sha512-5bZ+3CjhAd9eChYTHsjy6TGxpOFSKgKKJPJxr293jTbfry2KDoWkhBb6TcPVB4NmzaPhMs1Frm9AZH7OD4Cjzw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-whitespace": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-whitespace/-/micromark-factory-whitespace-2.0.1.tgz",
+      "integrity": "sha512-Ob0nuZ3PKt/n0hORHyvoD9uZhr+Za8sFoP+OnMcnWK5lngSzALgQYKMr9RJVOWLqQYuyn6ulqGWSXdwf6F80lQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-character": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.1.1.tgz",
+      "integrity": "sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-chunked": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-chunked/-/micromark-util-chunked-2.0.1.tgz",
+      "integrity": "sha512-QUNFEOPELfmvv+4xiNg2sRYeS/P84pTW0TCgP5zc9FpXetHY0ab7SxKyAQCNCc1eK0459uoLI1y5oO5Vc1dbhA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-classify-character": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-classify-character/-/micromark-util-classify-character-2.0.1.tgz",
+      "integrity": "sha512-K0kHzM6afW/MbeWYWLjoHQv1sgg2Q9EccHEDzSkxiP/EaagNzCm7T/WMKZ3rjMbvIpvBiZgwR3dKMygtA4mG1Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-combine-extensions": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-combine-extensions/-/micromark-util-combine-extensions-2.0.1.tgz",
+      "integrity": "sha512-OnAnH8Ujmy59JcyZw8JSbK9cGpdVY44NKgSM7E9Eh7DiLS2E9RNQf0dONaGDzEG9yjEl5hcqeIsj4hfRkLH/Bg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-decode-numeric-character-reference": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/micromark-util-decode-numeric-character-reference/-/micromark-util-decode-numeric-character-reference-2.0.2.tgz",
+      "integrity": "sha512-ccUbYk6CwVdkmCQMyr64dXz42EfHGkPQlBj5p7YVGzq8I7CtjXZJrubAYezf7Rp+bjPseiROqe7G6foFd+lEuw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-decode-string": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-decode-string/-/micromark-util-decode-string-2.0.1.tgz",
+      "integrity": "sha512-nDV/77Fj6eH1ynwscYTOsbK7rR//Uj0bZXBwJZRfaLEJ1iGBR6kIfNmlNqaqJf649EP0F3NWNdeJi03elllNUQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decode-named-character-reference": "^1.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-encode": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-encode/-/micromark-util-encode-2.0.1.tgz",
+      "integrity": "sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-html-tag-name": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-html-tag-name/-/micromark-util-html-tag-name-2.0.1.tgz",
+      "integrity": "sha512-2cNEiYDhCWKI+Gs9T0Tiysk136SnR13hhO8yW6BGNyhOC4qYFnwF1nKfD3HFAIXA5c45RrIG1ub11GiXeYd1xA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-normalize-identifier": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-normalize-identifier/-/micromark-util-normalize-identifier-2.0.1.tgz",
+      "integrity": "sha512-sxPqmo70LyARJs0w2UclACPUUEqltCkJ6PhKdMIDuJ3gSf/Q+/GIe3WKl0Ijb/GyH9lOpUkRAO2wp0GVkLvS9Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-resolve-all": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-resolve-all/-/micromark-util-resolve-all-2.0.1.tgz",
+      "integrity": "sha512-VdQyxFWFT2/FGJgwQnJYbe1jjQoNTS4RjglmSjTUlpUMa95Htx9NHeYW4rGDJzbjvCsl9eLjMQwGeElsqmzcHg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-sanitize-uri": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-2.0.1.tgz",
+      "integrity": "sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-encode": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-subtokenize": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-subtokenize/-/micromark-util-subtokenize-2.1.0.tgz",
+      "integrity": "sha512-XQLu552iSctvnEcgXw6+Sx75GflAPNED1qx7eBJ+wydBb2KCbRZe+NwvIEEMM83uml1+2WSXpBAcp9IUCgCYWA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-symbol": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-2.0.1.tgz",
+      "integrity": "sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-types": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-2.0.2.tgz",
+      "integrity": "sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/micromatch": {
       "version": "4.0.8",
@@ -5271,8 +6421,7 @@
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
     },
     "node_modules/nanoid": {
       "version": "3.3.11",
@@ -5599,6 +6748,31 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/parse-entities": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-4.0.2.tgz",
+      "integrity": "sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^2.0.0",
+        "character-entities-legacy": "^3.0.0",
+        "character-reference-invalid": "^2.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "is-alphanumerical": "^2.0.0",
+        "is-decimal": "^2.0.0",
+        "is-hexadecimal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/parse-entities/node_modules/@types/unist": {
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.11.tgz",
+      "integrity": "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==",
+      "license": "MIT"
+    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -5700,6 +6874,16 @@
         "react-is": "^16.13.1"
       }
     },
+    "node_modules/property-information": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/property-information/-/property-information-7.2.0.tgz",
+      "integrity": "sha512-IAtzIB6sUiWaJYrX9smp3V46pBGbBeLFRGdh25kg1334VcBlD8HzhPeNIWQH9zhGmo2itIe25EHt9dQP7G5hmg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -5759,6 +6943,33 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/react-markdown": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/react-markdown/-/react-markdown-10.1.0.tgz",
+      "integrity": "sha512-qKxVopLT/TyA6BX3Ue5NwabOsAzm0Q7kAPwq6L+wWDwisYs7R8vZ0nRXqq6rkueboxpkjvLGU9fWifiX/ZZFxQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "hast-util-to-jsx-runtime": "^2.0.0",
+        "html-url-attributes": "^3.0.0",
+        "mdast-util-to-hast": "^13.0.0",
+        "remark-parse": "^11.0.0",
+        "remark-rehype": "^11.0.0",
+        "unified": "^11.0.0",
+        "unist-util-visit": "^5.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      },
+      "peerDependencies": {
+        "@types/react": ">=18",
+        "react": ">=18"
+      }
+    },
     "node_modules/reflect.getprototypeof": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/reflect.getprototypeof/-/reflect.getprototypeof-1.0.10.tgz",
@@ -5799,6 +7010,72 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/remark-gfm": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/remark-gfm/-/remark-gfm-4.0.1.tgz",
+      "integrity": "sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-gfm": "^3.0.0",
+        "micromark-extension-gfm": "^3.0.0",
+        "remark-parse": "^11.0.0",
+        "remark-stringify": "^11.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-parse": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-11.0.0.tgz",
+      "integrity": "sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-rehype": {
+      "version": "11.1.2",
+      "resolved": "https://registry.npmjs.org/remark-rehype/-/remark-rehype-11.1.2.tgz",
+      "integrity": "sha512-Dh7l57ianaEoIpzbp0PC9UKAdCSVklD8E5Rpw7ETfbTl3FqcOOgq5q2LVDhgGCkaBv7p24JXikPdvhhmHvKMsw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "mdast-util-to-hast": "^13.0.0",
+        "unified": "^11.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-stringify": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/remark-stringify/-/remark-stringify-11.0.0.tgz",
+      "integrity": "sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/resolve": {
@@ -6148,6 +7425,16 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/space-separated-tokens": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/space-separated-tokens/-/space-separated-tokens-2.0.2.tgz",
+      "integrity": "sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/stable-hash": {
       "version": "0.0.5",
       "resolved": "https://registry.npmjs.org/stable-hash/-/stable-hash-0.0.5.tgz",
@@ -6278,6 +7565,20 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/stringify-entities": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-4.0.4.tgz",
+      "integrity": "sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==",
+      "license": "MIT",
+      "dependencies": {
+        "character-entities-html4": "^2.0.0",
+        "character-entities-legacy": "^3.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/strip-bom": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
@@ -6286,6 +7587,24 @@
       "license": "MIT",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/style-to-js": {
+      "version": "1.1.21",
+      "resolved": "https://registry.npmjs.org/style-to-js/-/style-to-js-1.1.21.tgz",
+      "integrity": "sha512-RjQetxJrrUJLQPHbLku6U/ocGtzyjbJMP9lCNK7Ag0CNh690nSH8woqWH9u16nMjYBAok+i7JO1NP2pOy8IsPQ==",
+      "license": "MIT",
+      "dependencies": {
+        "style-to-object": "1.0.14"
+      }
+    },
+    "node_modules/style-to-object": {
+      "version": "1.0.14",
+      "resolved": "https://registry.npmjs.org/style-to-object/-/style-to-object-1.0.14.tgz",
+      "integrity": "sha512-LIN7rULI0jBscWQYaSswptyderlarFkjQ+t79nzty8tcIAceVomEVlLzH5VP4Cmsv6MtKhs7qaAiwlcp+Mgaxw==",
+      "license": "MIT",
+      "dependencies": {
+        "inline-style-parser": "0.2.7"
       }
     },
     "node_modules/styled-jsx": {
@@ -6399,6 +7718,26 @@
       },
       "engines": {
         "node": ">=8.0"
+      }
+    },
+    "node_modules/trim-lines": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/trim-lines/-/trim-lines-3.0.1.tgz",
+      "integrity": "sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/trough": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/trough/-/trough-2.2.0.tgz",
+      "integrity": "sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/ts-api-utils": {
@@ -6597,6 +7936,93 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/unified": {
+      "version": "11.0.5",
+      "resolved": "https://registry.npmjs.org/unified/-/unified-11.0.5.tgz",
+      "integrity": "sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "bail": "^2.0.0",
+        "devlop": "^1.0.0",
+        "extend": "^3.0.0",
+        "is-plain-obj": "^4.0.0",
+        "trough": "^2.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-is": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-6.0.1.tgz",
+      "integrity": "sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-position": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-position/-/unist-util-position-5.0.0.tgz",
+      "integrity": "sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-stringify-position": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-4.0.0.tgz",
+      "integrity": "sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-5.1.0.tgz",
+      "integrity": "sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0",
+        "unist-util-visit-parents": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit-parents": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-6.0.2.tgz",
+      "integrity": "sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/unrs-resolver": {
       "version": "1.11.1",
       "resolved": "https://registry.npmjs.org/unrs-resolver/-/unrs-resolver-1.11.1.tgz",
@@ -6671,6 +8097,34 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/vfile": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/vfile/-/vfile-6.0.3.tgz",
+      "integrity": "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/vfile-message": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-4.0.3.tgz",
+      "integrity": "sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-stringify-position": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/which": {
@@ -6822,6 +8276,16 @@
       },
       "peerDependencies": {
         "zod": "^3.25.0 || ^4.0.0"
+      }
+    },
+    "node_modules/zwitch": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/zwitch/-/zwitch-2.0.4.tgz",
+      "integrity": "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -17,6 +17,8 @@
     "next": "^16.2.6",
     "react": "^19.2.6",
     "react-dom": "^19.2.6",
+    "react-markdown": "^10.1.0",
+    "remark-gfm": "^4.0.1",
     "sonner": "^2.0.7"
   },
   "devDependencies": {

--- a/scripts/convert-to-webp.ts
+++ b/scripts/convert-to-webp.ts
@@ -11,11 +11,13 @@ const OUTPUT_MAP: Record<string, string> = {
   "src/assets/logos": "public/logos",
 };
 
-// Size map for each directory
+// Size configs
 const SIZE_MAP: Record<string, { width: number; height: number }> = {
   "src/assets/logos": { width: 128, height: 128 },
-  "src/assets/projects": { width: 800, height: 450 },
 };
+
+// Images named "cover" get the cover crop; everything else is just constrained
+const COVER_SIZE = { width: 800, height: 450 };
 
 // Files to skip
 const SKIP = ["avatar.png"];
@@ -32,7 +34,6 @@ function* walkDir(dir: string): Generator<string> {
 // Convert all PNGs in each target directory to WebP
 async function main() {
   for (const dir of CONVERT_DIRS) {
-    const size = SIZE_MAP[dir];
     const outDir = OUTPUT_MAP[dir];
 
     for (const file of walkDir(dir)) {
@@ -49,13 +50,26 @@ async function main() {
       // Ensure output directory exists
       mkdirSync(dirname(output), { recursive: true });
 
-      await sharp(file)
-        .resize(size.width, size.height, {
-          fit: "inside",
-          withoutEnlargement: true,
-        })
-        .webp({ quality: 85 })
-        .toFile(output);
+      const name = basename(file, ".png");
+      const size =
+        name === "cover"
+          ? COVER_SIZE
+          : SIZE_MAP[dir];
+
+      if (size) {
+        await sharp(file)
+          .resize(size.width, size.height, {
+            fit: "inside",
+            withoutEnlargement: true,
+          })
+          .webp({ quality: 85 })
+          .toFile(output);
+      } else {
+        await sharp(file)
+          .resize({ width: 1200, withoutEnlargement: true })
+          .webp({ quality: 85 })
+          .toFile(output);
+      }
 
       console.log(`\x1b[32m✓\x1b[0m converted \x1b[36m${file}\x1b[0m to webp`);
     }

--- a/src/app/(main)/projects/[slug]/page.tsx
+++ b/src/app/(main)/projects/[slug]/page.tsx
@@ -207,7 +207,7 @@ const markdownComponents: Components = {
     );
   },
   pre: ({ children }) => (
-    <pre className="bg-zinc-100 dark:bg-zinc-800 rounded-xl p-4 mb-4 overflow-hidden text-sm border border-zinc-200 dark:border-zinc-700 [&>code]:block [&>code]:overflow-x-auto" style={{ clipPath: "inset(0 round 0.75rem)" }}>
+    <pre className="rounded-xl mb-4 border border-zinc-200 dark:border-zinc-700 bg-zinc-100 dark:bg-zinc-800 overflow-x-auto p-4 text-sm [&>code]:block" style={{ clipPath: "inset(0 round 0.75rem)" }}>
       {children}
     </pre>
   ),

--- a/src/app/(main)/projects/[slug]/page.tsx
+++ b/src/app/(main)/projects/[slug]/page.tsx
@@ -1,7 +1,21 @@
 import { Metadata } from "next";
 import { notFound } from "next/navigation";
+import fs from "fs";
+import path from "path";
+import Image from "next/image";
+import ReactMarkdown from "react-markdown";
+import remarkGfm from "remark-gfm";
+import type { Components } from "react-markdown";
 
 import { websiteURL, projects } from "@/lib/site";
+import Pill from "@/components/ui/Pill";
+import Tooltip from "@/components/ui/Tooltip";
+import {
+  IconExternalLink,
+  IconCodeblock,
+  IconArrowLeft,
+} from "@tabler/icons-react";
+import Link from "next/link";
 
 export async function generateMetadata({
   params,
@@ -28,7 +42,7 @@ export async function generateMetadata({
 }
 
 export function generateStaticParams() {
-  return projects.filter((p) => p.visible !== false).map((p) => ({ slug: p.slug }));
+  return projects.map((p) => ({ slug: p.slug }));
 }
 
 export default async function Project({
@@ -37,22 +51,175 @@ export default async function Project({
   params: Promise<{ slug: string }>;
 }) {
   const { slug } = await params;
-  const project = projects.find((p) => p.slug === slug && p.visible !== false);
+  const project = projects.find((p) => p.slug === slug);
   if (!project) notFound();
+
+  const contentPath = path.join(
+    process.cwd(),
+    "src/content/projects",
+    `${slug}.md`
+  );
+  let markdownContent: string | null = null;
+  try {
+    markdownContent = fs.readFileSync(contentPath, "utf-8");
+  } catch {
+    // No markdown file — fall back to simple view
+  }
 
   return (
     <section className="w-full">
-      <div className="mx-auto max-w-4xl flex flex-col px-6 sm:px-10 text-center gap-3">
-        <h1 className="text-2xl font-semibold text-zinc-700 dark:text-zinc-300">
-          {project.title}
-        </h1>
+      <div className="mx-auto max-w-3xl flex flex-col px-6 sm:px-10">
+        {/* Back link */}
+        <Link
+          href="/projects/"
+          className="flex items-center gap-1.5 text-sm text-zinc-400 dark:text-zinc-500 hover:text-zinc-600 dark:hover:text-zinc-300 transition-colors mb-8 w-fit"
+        >
+          <IconArrowLeft size={16} className="overflow-clip" />
+          Back to projects
+        </Link>
 
-        {project.description && (
-          <p className="text-sm text-zinc-600 dark:text-zinc-400">
-            {project.description}
+        {/* Cover Image */}
+        {project.cover && (
+          <div className="rounded-2xl mb-8">
+            <Image
+              src={project.cover}
+              alt={`${project.title} cover`}
+              width={800}
+              height={450}
+              priority
+              className="w-full h-auto object-cover rounded-2xl"
+            />
+          </div>
+        )}
+
+        {/* Title + Tags + Links */}
+        <div className="flex flex-col gap-3 mb-10">
+          <h1 className="text-2xl font-semibold text-zinc-700 dark:text-zinc-300">
+            {project.title}
+          </h1>
+
+          {project.description && (
+            <p className="text-sm text-zinc-600 dark:text-zinc-400">
+              {project.description}
+            </p>
+          )}
+
+          <div className="flex items-center gap-3 mt-2">
+            <div className="flex flex-wrap gap-1.5">
+              {project.tags.map((tag, i) => (
+                <Pill key={i} text={tag} />
+              ))}
+            </div>
+
+            <div className="flex items-center gap-2 ml-auto">
+              {project.url && (
+                <Tooltip content="View Live">
+                  <a
+                    aria-label={`View ${project.title} live`}
+                    href={project.url}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="transition-colors text-zinc-400 dark:text-zinc-400 hover:text-zinc-500 dark:hover:text-zinc-300"
+                  >
+                    <IconExternalLink size={20} className="overflow-clip" />
+                  </a>
+                </Tooltip>
+              )}
+              {project.repo && (
+                <Tooltip content="View Source Code">
+                  <a
+                    aria-label={`View ${project.title} repository`}
+                    href={project.repo}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="transition-colors text-zinc-400 dark:text-zinc-400 hover:text-zinc-500 dark:hover:text-zinc-300"
+                  >
+                    <IconCodeblock size={20} className="overflow-clip" />
+                  </a>
+                </Tooltip>
+              )}
+            </div>
+          </div>
+        </div>
+
+        {/* Markdown Content or Simple Fallback */}
+        {markdownContent ? (
+          <div className="prose-custom pb-20">
+            <ReactMarkdown
+              remarkPlugins={[remarkGfm]}
+              components={markdownComponents}
+            >
+              {markdownContent}
+            </ReactMarkdown>
+          </div>
+        ) : (
+          <p className="text-sm text-zinc-500 dark:text-zinc-400 pb-20">
+            No additional content yet.
           </p>
         )}
       </div>
     </section>
   );
 }
+
+const markdownComponents: Components = {
+  h2: ({ children }) => (
+    <h2 className="text-xl font-semibold text-zinc-700 dark:text-zinc-300 mt-10 mb-4 first:mt-0">
+      {children}
+    </h2>
+  ),
+  h3: ({ children }) => (
+    <h3 className="text-lg font-semibold text-zinc-700 dark:text-zinc-300 mt-8 mb-3">
+      {children}
+    </h3>
+  ),
+  p: ({ children }) => (
+    <p className="text-sm text-zinc-600 dark:text-zinc-400 leading-relaxed mb-4 last:mb-0">
+      {children}
+    </p>
+  ),
+  img: ({ src, alt }) => (
+    <img
+      src={src}
+      alt={alt ?? ""}
+      className="w-full rounded-xl my-6"
+      loading="lazy"
+    />
+  ),
+  a: ({ href, children }) => (
+    <a
+      href={href}
+      target="_blank"
+      rel="noopener noreferrer"
+      className="text-zinc-600 dark:text-zinc-400 underline decoration-zinc-300 dark:decoration-zinc-600 underline-offset-2 hover:text-zinc-800 dark:hover:text-zinc-200 hover:decoration-zinc-500 transition-colors"
+    >
+      {children}
+    </a>
+  ),
+  ul: ({ children }) => (
+    <ul className="list-disc list-outside text-sm text-zinc-600 dark:text-zinc-400 ml-5 mb-4 space-y-1.5">
+      {children}
+    </ul>
+  ),
+  ol: ({ children }) => (
+    <ol className="list-decimal list-outside text-sm text-zinc-600 dark:text-zinc-400 ml-5 mb-4 space-y-1.5">
+      {children}
+    </ol>
+  ),
+  code: ({ children }) => (
+    <code className="font-mono text-sm bg-zinc-100 dark:bg-zinc-800 px-1.5 py-0.5 rounded text-zinc-700 dark:text-zinc-300">
+      {children}
+    </code>
+  ),
+  pre: ({ children }) => (
+    <pre className="bg-zinc-100 dark:bg-zinc-800 rounded-xl p-4 mb-4 overflow-x-auto text-sm border border-zinc-200 dark:border-zinc-700">
+      {children}
+    </pre>
+  ),
+  blockquote: ({ children }) => (
+    <blockquote className="border-l-4 border-zinc-300 dark:border-zinc-600 pl-4 italic text-zinc-500 dark:text-zinc-400 mb-4">
+      {children}
+    </blockquote>
+  ),
+  hr: () => <hr className="border-zinc-200 dark:border-zinc-700 my-8" />,
+};

--- a/src/app/(main)/projects/[slug]/page.tsx
+++ b/src/app/(main)/projects/[slug]/page.tsx
@@ -9,7 +9,6 @@ import type { Components } from "react-markdown";
 
 import { websiteURL, projects } from "@/lib/site";
 import Pill from "@/components/ui/Pill";
-import Tooltip from "@/components/ui/Tooltip";
 import {
   IconExternalLink,
   IconCodeblock,
@@ -69,15 +68,6 @@ export default async function Project({
   return (
     <section className="w-full">
       <div className="mx-auto max-w-3xl flex flex-col px-6 sm:px-10">
-        {/* Back link */}
-        <Link
-          href="/projects/"
-          className="flex items-center gap-1.5 text-sm text-zinc-400 dark:text-zinc-500 hover:text-zinc-600 dark:hover:text-zinc-300 transition-colors mb-8 w-fit"
-        >
-          <IconArrowLeft size={16} className="overflow-clip" />
-          Back to projects
-        </Link>
-
         {/* Cover Image */}
         {project.cover && (
           <div className="rounded-2xl mb-8">
@@ -92,59 +82,48 @@ export default async function Project({
           </div>
         )}
 
-        {/* Title + Tags + Links */}
-        <div className="flex flex-col gap-3 mb-10">
+        {/* Title + Links */}
+        <div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between mb-6 md:mb-4">
           <h1 className="text-2xl font-semibold text-zinc-700 dark:text-zinc-300">
             {project.title}
           </h1>
 
-          {project.description && (
-            <p className="text-sm text-zinc-600 dark:text-zinc-400">
-              {project.description}
-            </p>
-          )}
-
-          <div className="flex items-center gap-3 mt-2">
-            <div className="flex flex-wrap gap-1.5">
-              {project.tags.map((tag, i) => (
-                <Pill key={i} text={tag} />
-              ))}
-            </div>
-
-            <div className="flex items-center gap-2 ml-auto">
-              {project.url && (
-                <Tooltip content="View Live">
-                  <a
-                    aria-label={`View ${project.title} live`}
-                    href={project.url}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="transition-colors text-zinc-400 dark:text-zinc-400 hover:text-zinc-500 dark:hover:text-zinc-300"
-                  >
-                    <IconExternalLink size={20} className="overflow-clip" />
-                  </a>
-                </Tooltip>
-              )}
-              {project.repo && (
-                <Tooltip content="View Source Code">
-                  <a
-                    aria-label={`View ${project.title} repository`}
-                    href={project.repo}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="transition-colors text-zinc-400 dark:text-zinc-400 hover:text-zinc-500 dark:hover:text-zinc-300"
-                  >
-                    <IconCodeblock size={20} className="overflow-clip" />
-                  </a>
-                </Tooltip>
-              )}
-            </div>
+          <div className="flex items-center gap-4 shrink-0 sm:mt-1">
+            {project.url && (
+              <a
+                href={project.url}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="inline-flex items-center gap-1 text-sm text-zinc-500 dark:text-zinc-400 underline decoration-zinc-300 dark:decoration-zinc-600 underline-offset-2 hover:text-zinc-700 dark:hover:text-zinc-200 transition-colors"
+              >
+                <IconExternalLink size={13} className="overflow-clip" />
+                View Live
+              </a>
+            )}
+            {project.repo && (
+              <a
+                href={project.repo}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="inline-flex items-center gap-1 text-sm text-zinc-500 dark:text-zinc-400 underline decoration-zinc-300 dark:decoration-zinc-600 underline-offset-2 hover:text-zinc-700 dark:hover:text-zinc-200 transition-colors"
+              >
+                <IconCodeblock size={13} className="overflow-clip" />
+                View Repository
+              </a>
+            )}
           </div>
+        </div>
+
+        {/* Tags */}
+        <div className="flex flex-wrap gap-1.5 mb-16 max-w-md">
+          {project.tags.map((tag, i) => (
+            <Pill key={i} text={tag} />
+          ))}
         </div>
 
         {/* Markdown Content or Simple Fallback */}
         {markdownContent ? (
-          <div className="prose-custom pb-20">
+          <div className="prose-custom">
             <ReactMarkdown
               remarkPlugins={[remarkGfm]}
               components={markdownComponents}
@@ -164,12 +143,12 @@ export default async function Project({
 
 const markdownComponents: Components = {
   h2: ({ children }) => (
-    <h2 className="text-xl font-semibold text-zinc-700 dark:text-zinc-300 mt-10 mb-4 first:mt-0">
+    <h2 className="text-xl font-semibold text-zinc-700 dark:text-zinc-300 mt-10 mb-4 pb-3 border-b border-zinc-300 dark:border-zinc-800 first:mt-0">
       {children}
     </h2>
   ),
   h3: ({ children }) => (
-    <h3 className="text-lg font-semibold text-zinc-700 dark:text-zinc-300 mt-8 mb-3">
+    <h3 className="text-base font-medium text-zinc-700 dark:text-zinc-300 mt-6 mb-2">
       {children}
     </h3>
   ),
@@ -179,10 +158,12 @@ const markdownComponents: Components = {
     </p>
   ),
   img: ({ src, alt }) => (
-    <img
-      src={src}
+    <Image
+      src={src as string}
       alt={alt ?? ""}
-      className="w-full rounded-xl my-6"
+      width={800}
+      height={450}
+      className="w-full h-auto rounded-xl my-6"
       loading="lazy"
     />
   ),
@@ -207,7 +188,7 @@ const markdownComponents: Components = {
     </ol>
   ),
   code: ({ children }) => (
-    <code className="font-mono text-sm bg-zinc-100 dark:bg-zinc-800 px-1.5 py-0.5 rounded text-zinc-700 dark:text-zinc-300">
+    <code className="font-mono text-xs bg-zinc-200 dark:bg-zinc-800 px-1.5 py-0.5 rounded text-zinc-700 dark:text-zinc-300">
       {children}
     </code>
   ),

--- a/src/app/(main)/projects/[slug]/page.tsx
+++ b/src/app/(main)/projects/[slug]/page.tsx
@@ -187,15 +187,53 @@ const markdownComponents: Components = {
       {children}
     </ol>
   ),
-  code: ({ children }) => (
-    <code className="font-mono text-xs bg-zinc-200 dark:bg-zinc-800 px-1.5 py-0.5 rounded text-zinc-700 dark:text-zinc-300">
-      {children}
-    </code>
-  ),
+  code: ({ children, className }) => {
+    // Code blocks contain newlines; inline code does not
+    const text = children?.toString() ?? "";
+    const isBlock = text.includes("\n");
+
+    if (isBlock) {
+      return (
+        <code className={`font-mono text-xs ${className ?? ""}`}>
+          {children}
+        </code>
+      );
+    }
+
+    return (
+      <code className="font-mono text-xs bg-zinc-200 dark:bg-zinc-800 px-1.5 py-0.5 rounded text-zinc-700 dark:text-zinc-300">
+        {children}
+      </code>
+    );
+  },
   pre: ({ children }) => (
-    <pre className="bg-zinc-100 dark:bg-zinc-800 rounded-xl p-4 mb-4 overflow-x-auto text-sm border border-zinc-200 dark:border-zinc-700">
+    <pre className="bg-zinc-100 dark:bg-zinc-800 rounded-xl p-4 mb-4 overflow-hidden text-sm border border-zinc-200 dark:border-zinc-700 [&>code]:block [&>code]:overflow-x-auto" style={{ clipPath: "inset(0 round 0.75rem)" }}>
       {children}
     </pre>
+  ),
+  table: ({ children }) => (
+    <div className="overflow-x-auto mb-4">
+      <table className="w-full text-sm text-zinc-600 dark:text-zinc-400 border-collapse border border-zinc-200 dark:border-zinc-700">
+        {children}
+      </table>
+    </div>
+  ),
+  thead: ({ children }) => (
+    <thead className="bg-zinc-100 dark:bg-zinc-800/50">{children}</thead>
+  ),
+  tbody: ({ children }) => <tbody>{children}</tbody>,
+  tr: ({ children }) => (
+    <tr className="border-b border-zinc-200 dark:border-zinc-700 last:border-none">
+      {children}
+    </tr>
+  ),
+  th: ({ children }) => (
+    <th className="text-left font-semibold text-zinc-700 dark:text-zinc-300 px-3 py-2.5 whitespace-nowrap">
+      {children}
+    </th>
+  ),
+  td: ({ children }) => (
+    <td className="px-3 py-2.5 text-sm">{children}</td>
   ),
   blockquote: ({ children }) => (
     <blockquote className="border-l-4 border-zinc-300 dark:border-zinc-600 pl-4 italic text-zinc-500 dark:text-zinc-400 mb-4">

--- a/src/app/coming-soon.tsx
+++ b/src/app/coming-soon.tsx
@@ -6,7 +6,6 @@ import Button from "@/components/ui/Button";
 const SITE_MODE = process.env.NEXT_PUBLIC_SITE_MODE;
 
 const wip = new Set([
-  "/projects/l2c-portal/",
   "/projects/hangman/",
   "/projects/cymo-gpt/",
   "/projects/pmc-business/",

--- a/src/app/coming-soon.tsx
+++ b/src/app/coming-soon.tsx
@@ -6,7 +6,6 @@ import Button from "@/components/ui/Button";
 const SITE_MODE = process.env.NEXT_PUBLIC_SITE_MODE;
 
 const wip = new Set([
-  "/projects/digital-portfolio/",
   "/projects/l2c-portal/",
   "/projects/hangman/",
   "/projects/cymo-gpt/",

--- a/src/components/sections/home/Stack.tsx
+++ b/src/components/sections/home/Stack.tsx
@@ -79,6 +79,7 @@ function getStackColor(tech: string, isDark: boolean): string | undefined {
     // CI/CD
     Git: { light: "#ea580c", dark: "#F05032" },
     "GitHub Actions": { light: "#6b7280", dark: "#CCCCCC" },
+    "GitLab CI": { light: "#d97706", dark: "#FC6D26" },
     // Scripting
     Bash: { light: "#16a34a", dark: "#4EAA25" },
     Makefile: { light: "#a855f7", dark: "#A0A0A0" },

--- a/src/components/sections/home/Stats.tsx
+++ b/src/components/sections/home/Stats.tsx
@@ -329,9 +329,9 @@ function wakatimeStat(wakatimeStats: WakatimeStats | null): StatItemType {
     sublabel: (
       <>
         <span className="font-mono">
-          {wakatimeStats?.monthly.toLocaleString()}
+          {wakatimeStats?.yearly.toLocaleString()}
         </span>{" "}
-        hours coded this month
+        hours coded this year
       </>
     ),
     ready: wakatimeStats !== null,

--- a/src/components/ui/Breadcrumb.tsx
+++ b/src/components/ui/Breadcrumb.tsx
@@ -17,25 +17,25 @@ export default function Breadcrumb({ separator = "/" }: Props) {
 
   return (
     <nav className="font-console text-[11px] sm:text-xs font-medium uppercase tracking-[0.2em] text-zinc-400 dark:text-zinc-500 flex items-center gap-2">
-      <span className="hidden sm:inline">
-        {!showEllipsis && (
-          <Link href="/" className="hover:text-zinc-600 dark:hover:text-zinc-300">
-            Home
-          </Link>
-        )}
-        {showEllipsis && (
+      {!showEllipsis && (
+        <Link href="/" className="hover:text-zinc-600 dark:hover:text-zinc-300">
+          Home
+        </Link>
+      )}
+      {showEllipsis && (
+        <span className="hidden sm:inline">
           <Link href={ellipsisHref} className="hover:text-zinc-600 dark:hover:text-zinc-300">
             ..
           </Link>
-        )}
-      </span>
+        </span>
+      )}
       {visibleSegments.map((segment, i) => {
         const href = "/" + segments.slice(0, segments.length - 2 + i + 1).join("/");
         const label = segment.replaceAll("-", " ");
 
         return (
           <span key={href} className="flex items-center gap-2">
-            <span className={`text-zinc-200 dark:text-zinc-700 ${i === 0 ? "hidden sm:inline" : ""}`}>
+            <span className={`text-zinc-200 dark:text-zinc-700 ${i === 0 && showEllipsis ? "hidden sm:inline" : ""}`}>
               {separator}
             </span>
             {i === segments.length - 1 ? (

--- a/src/components/ui/Breadcrumb.tsx
+++ b/src/components/ui/Breadcrumb.tsx
@@ -17,25 +17,27 @@ export default function Breadcrumb({ separator = "/" }: Props) {
 
   return (
     <nav className="font-console text-[11px] sm:text-xs font-medium uppercase tracking-[0.2em] text-zinc-400 dark:text-zinc-500 flex items-center gap-2">
-      {!showEllipsis && (
-        <Link href="/" className="hover:text-zinc-600 dark:hover:text-zinc-300">
-          Home
-        </Link>
-      )}
-      {showEllipsis && (
-        <>
+      <span className="hidden sm:inline">
+        {!showEllipsis && (
+          <Link href="/" className="hover:text-zinc-600 dark:hover:text-zinc-300">
+            Home
+          </Link>
+        )}
+        {showEllipsis && (
           <Link href={ellipsisHref} className="hover:text-zinc-600 dark:hover:text-zinc-300">
             ..
           </Link>
-        </>
-      )}
+        )}
+      </span>
       {visibleSegments.map((segment, i) => {
         const href = "/" + segments.slice(0, segments.length - 2 + i + 1).join("/");
         const label = segment.replaceAll("-", " ");
 
         return (
           <span key={href} className="flex items-center gap-2">
-            <span className="text-zinc-200 dark:text-zinc-700">{separator}</span>
+            <span className={`text-zinc-200 dark:text-zinc-700 ${i === 0 ? "hidden sm:inline" : ""}`}>
+              {separator}
+            </span>
             {i === segments.length - 1 ? (
               <span className="pointer-events-none">{label}</span>
             ) : (

--- a/src/content/projects/digital-portfolio.md
+++ b/src/content/projects/digital-portfolio.md
@@ -1,0 +1,53 @@
+## Overview
+
+This is my personal portfolio — the site you're currently browsing. It serves as a central hub to showcase my projects, career journey, technical skills, and a bit about who I am. Built from the ground up with a focus on performance, clean design, and maintainability.
+
+## Tech Stack
+
+- **Framework:** Next.js 16 (App Router, static export)
+- **Styling:** Tailwind CSS v4 with dark mode
+- **Animations:** GSAP for scroll and hover interactions
+- **Icons:** Tabler Icons
+- **Deployment:** AWS S3 + CloudFront via Terraform
+- **CI/CD:** GitHub Actions
+
+## Why Static Export?
+
+I wanted the site to be as fast and reliable as possible without managing a server. Static export means every page is pre-rendered to HTML at build time — no server-side rendering, no database queries, no runtime overhead. The result is a blazing-fast site that can be served from any CDN.
+
+![S3 and CloudFront architecture](/projects/digital-portfolio/cover.webp)
+
+The site is deployed to an S3 bucket behind CloudFront, with Terraform managing the infrastructure as code. This makes deployments reproducible and infrastructure changes auditable.
+
+## Design Decisions
+
+### Clean and Minimal
+
+The design focuses on readability and content hierarchy. I chose the Zinc color palette for its neutrality and paired it with Inter for body text and Spline Sans Mono for code and metadata elements.
+
+### Dark Mode
+
+Dark mode was a must-have. The implementation uses a CSS custom property approach via `@wrksz/themes`, with a toggle that persists the preference. View transitions are animated for a polished feel.
+
+### Performance
+
+Every image is converted to WebP at build time. The site scores 95+ on Lighthouse across all categories. Fonts are self-hosted to avoid external requests.
+
+## Project Structure
+
+Key directories and their purpose:
+
+- `src/app/` — Next.js App Router pages and layouts
+- `src/components/` — Reusable React components (header, footer, cards, pills)
+- `src/hooks/` — Custom React hooks (animations, environment detection)
+- `src/lib/` — Site configuration, types, and data
+- `src/assets/` — Source images (converted to WebP at build)
+- `scripts/` — Build-time tooling (image conversion, etc.)
+
+## What I Learned
+
+Building this portfolio reinforced a few principles I try to follow in every project:
+
+1. **Start with the content model.** Defining the `Project`, `Career`, and `Education` types upfront made the rest of the site straightforward to build.
+2. **Static doesn't mean boring.** GSAP animations and thoughtful transitions make the site feel interactive without compromising performance.
+3. **Infrastructure as code is worth it.** Being able to `terraform apply` and have the entire AWS stack provisioned consistently is a huge time saver.

--- a/src/content/projects/l2c-portal.md
+++ b/src/content/projects/l2c-portal.md
@@ -1,0 +1,150 @@
+## Live Deployment
+
+The site is deployed at [rsoconnect.powermaccenter.com](https://rsoconnect.powermaccenter.com).
+
+---
+
+## Features
+
+- **Lead Management**: Capture, track, and qualify new customer leads from walk-in customers
+- **Waiver Management**: Digital job orders and setup activation forms with PDF generation and e-signatures
+- **Product Configuration**: Dynamic product selection with specifications
+- **Multi-Location Support**: Hierarchical location management (Territory → Area → Branch)
+- **Advanced Filtering**: Search and filter leads by status, location, product category, and date ranges
+- **Lead Status Tracking**: Monitor leads through various stages (New, Notified, Pending, Served)
+- **Customer Data Management**: Centralized customer database with 1nfinite integration support
+- **Role-Based Access**: Different dashboard views for Mac Experts, Branch Heads, Area Managers, Territory Managers, and Directors
+- **Two-Factor Authentication**: Email OTP verification with optional trusted device support
+- **Responsive Design**: Optimized for both desktop and mobile devices
+- **Automated Database Backups**: Daily scheduled backups with automatic cleanup and retention policy
+- **Observability Stack**: Real-time error tracking with Sentry and metrics/log aggregation via Grafana, Prometheus, and Loki
+
+---
+
+## Technologies Used
+
+- **Backend:** Django 5.2, Django Ninja (REST API), Celery + Celery Beat (async & scheduled tasks)
+- **Frontend:** TailwindCSS v4, CSS/JS
+- **Database:** PostgreSQL 16
+- **Cache / Broker:** Redis 7
+- **Admin Interface:** Django Unfold
+- **Additional:** `django-money`, `django-phonenumber-field`, `django-allauth`, `django-currentuser`, `django-import-export`, `django-simple-history`, `django-otp`, `weasyprint`
+- **Deployment:** Docker, Nginx, Gunicorn
+- **Monitoring & Observability:** Sentry (error tracking), Grafana, Prometheus, Loki (metrics & log aggregation)
+- **Infrastructure:** Ansible (server provisioning)
+
+---
+
+## Project Structure
+
+```
+l2c-portal/
+├── .github/workflows/            # GitHub Actions workflows
+├── ansible/                      # Ansible playbooks for server provisioning
+│   ├── inventory.ini             # Server inventory (staging, prod)
+│   └── playbooks/
+│       └── setup-server.yml      # Server setup playbook
+├── apps/                         # Django applications
+│   ├── core/                     # Base views, mixins, and shared management commands
+│   ├── leads/                    # Lead and customer management
+│   ├── locations/                # Territory, Area, Branch, and Service Center models
+│   ├── products/                 # Product catalog and specs
+│   ├── users/                    # User management, authentication, and 2FA
+│   └── waivers/                  # Job orders and setup activation forms
+├── config/                       # Django project configuration
+│   ├── settings/                 # Environment-specific settings
+│   │   ├── base.py               # Shared base settings
+│   │   ├── dev.py                # Development settings
+│   │   ├── staging.py            # Staging settings
+│   │   └── prod.py               # Production settings
+│   ├── celery.py                 # Celery configuration
+│   └── urls.py                   # Root URL configuration
+├── data/                         # CSV seed files for management commands
+├── docs/                         # Documentation
+├── monitoring/                   # Monitoring configuration (Prometheus, Promtail)
+├── nginx/                        # Nginx configuration
+├── scripts/                      # Server setup and utility scripts
+├── static/                       # Project-wide static files
+├── templates/                    # HTML templates
+├── docker-compose.yml            # Docker Compose service definitions
+├── Dockerfile.dev                # Docker image for development
+├── Dockerfile.prod               # Docker image for production
+├── makefile                      # Custom project commands
+└── pyproject.toml                # Python project configuration
+```
+
+---
+
+## Getting Started
+
+### Prerequisites
+
+- **Docker Desktop** ([docker.com](https://www.docker.com/products/docker-desktop/))
+- **uv** (Python package manager)
+- **Ansible** — for server provisioning
+
+### Installation
+
+Clone the repository and configure your environment:
+
+```bash
+git clone https://github.com/PMC-BIT/l2c-portal.git
+cd l2c-portal
+cp .env.example .env
+```
+
+Key environment variables:
+
+| Variable | Description |
+|---|---|
+| `ENVIRONMENT` | `dev`, `staging`, or `prod` |
+| `POSTGRES_DB` | PostgreSQL database name |
+| `POSTGRES_USER` | PostgreSQL username |
+| `POSTGRES_PASSWORD` | PostgreSQL password |
+| `SECRET_KEY` | Django secret key |
+| `DEBUG` | `True` for development, `False` for production |
+| `ALLOWED_HOSTS` | Comma-separated allowed hostnames |
+| `REDIS_URL` | Redis connection URL |
+
+The project uses two SMTP accounts to avoid hitting daily sending limits — Gmail for low-priority emails and GoDaddy for high-priority (OTP, welcome, password reset).
+
+### Setup
+
+```bash
+make setup-dev
+```
+
+This creates containers, applies migrations, and creates a superuser. For normal startups afterward, use `make start`.
+
+### Server Provisioning
+
+Add the server IP to `ansible/inventory.ini` and run:
+
+```bash
+ansible-playbook -i ansible/inventory.ini ansible/playbooks/setup-server.yml --limit production --ask-pass --ask-become-pass
+```
+
+---
+
+## Development Notes
+
+### Environment Differences
+
+| Setting | Dev | Staging | Prod |
+|---|---|---|---|
+| `DEBUG` | `True` | `True` | `False` |
+| `SSL/HTTPS` | Disabled | Disabled | Configurable |
+| `CSP` | Report-only | Enforced | Enforced |
+| `LOG_LEVEL` | `DEBUG` | `INFO` | `WARNING` |
+
+### Monitoring
+
+| Service | URL | Purpose |
+|---|---|---|
+| Grafana | `http://localhost:3000` | Metrics dashboards |
+| Prometheus | `http://localhost:9090` | Raw metrics |
+| Loki | `http://localhost:3100` | Log aggregation |
+
+### Sentry
+
+Set `SENTRY_DSN` in `.env` to enable error tracking. Errors are tagged by environment — check the correct filter in the Sentry dashboard.

--- a/src/content/projects/l2c-portal.md
+++ b/src/content/projects/l2c-portal.md
@@ -2,8 +2,6 @@
 
 Enterprise CRM platform built for a retail company serving 1–2K users across a 3-tier location hierarchy. The system manages leads, waivers, product configurations, and customer data with role-based dashboards at each tier.
 
----
-
 ## My Contribution
 
 Sole infrastructure engineer and backend lead. Delivered MVP in two weeks.
@@ -22,13 +20,9 @@ CI/CD via self-hosted GitHub Actions runners with pull request checks, linting, 
 
 Sentry for real-time error tracking with full stack traces across environments. Grafana, Prometheus, and Loki for metrics and log aggregation. Automated daily PostgreSQL backups with tiered retention.
 
----
-
 ## What I Learned
 
 End-to-end ownership of a production system — database design, API architecture, server provisioning, CI/CD, and monitoring. Working without a senior on the infrastructure side required independent research, cross-referencing multiple sources, and deliberate architectural decisions.
-
----
 
 ## Technologies
 

--- a/src/content/projects/l2c-portal.md
+++ b/src/content/projects/l2c-portal.md
@@ -1,150 +1,40 @@
-## Live Deployment
+## Overview
 
-The site is deployed at [rsoconnect.powermaccenter.com](https://rsoconnect.powermaccenter.com).
-
----
-
-## Features
-
-- **Lead Management**: Capture, track, and qualify new customer leads from walk-in customers
-- **Waiver Management**: Digital job orders and setup activation forms with PDF generation and e-signatures
-- **Product Configuration**: Dynamic product selection with specifications
-- **Multi-Location Support**: Hierarchical location management (Territory → Area → Branch)
-- **Advanced Filtering**: Search and filter leads by status, location, product category, and date ranges
-- **Lead Status Tracking**: Monitor leads through various stages (New, Notified, Pending, Served)
-- **Customer Data Management**: Centralized customer database with 1nfinite integration support
-- **Role-Based Access**: Different dashboard views for Mac Experts, Branch Heads, Area Managers, Territory Managers, and Directors
-- **Two-Factor Authentication**: Email OTP verification with optional trusted device support
-- **Responsive Design**: Optimized for both desktop and mobile devices
-- **Automated Database Backups**: Daily scheduled backups with automatic cleanup and retention policy
-- **Observability Stack**: Real-time error tracking with Sentry and metrics/log aggregation via Grafana, Prometheus, and Loki
+Enterprise CRM platform built for a retail company serving 1–2K users across a 3-tier location hierarchy. The system manages leads, waivers, product configurations, and customer data with role-based dashboards at each tier.
 
 ---
 
-## Technologies Used
+## My Contribution
 
-- **Backend:** Django 5.2, Django Ninja (REST API), Celery + Celery Beat (async & scheduled tasks)
-- **Frontend:** TailwindCSS v4, CSS/JS
-- **Database:** PostgreSQL 16
-- **Cache / Broker:** Redis 7
-- **Admin Interface:** Django Unfold
-- **Additional:** `django-money`, `django-phonenumber-field`, `django-allauth`, `django-currentuser`, `django-import-export`, `django-simple-history`, `django-otp`, `weasyprint`
-- **Deployment:** Docker, Nginx, Gunicorn
-- **Monitoring & Observability:** Sentry (error tracking), Grafana, Prometheus, Loki (metrics & log aggregation)
-- **Infrastructure:** Ansible (server provisioning)
+Sole infrastructure engineer and backend lead. Delivered MVP in two weeks.
 
----
+### Backend & API
 
-## Project Structure
+Django Ninja REST API with RBAC across all endpoints — four permission levels controlling dashboard views and data access per location tier. Two-factor authentication with trusted device support, rate limiting on login attempts, and async bulk user import with per-row error reporting.
 
-```
-l2c-portal/
-├── .github/workflows/            # GitHub Actions workflows
-├── ansible/                      # Ansible playbooks for server provisioning
-│   ├── inventory.ini             # Server inventory (staging, prod)
-│   └── playbooks/
-│       └── setup-server.yml      # Server setup playbook
-├── apps/                         # Django applications
-│   ├── core/                     # Base views, mixins, and shared management commands
-│   ├── leads/                    # Lead and customer management
-│   ├── locations/                # Territory, Area, Branch, and Service Center models
-│   ├── products/                 # Product catalog and specs
-│   ├── users/                    # User management, authentication, and 2FA
-│   └── waivers/                  # Job orders and setup activation forms
-├── config/                       # Django project configuration
-│   ├── settings/                 # Environment-specific settings
-│   │   ├── base.py               # Shared base settings
-│   │   ├── dev.py                # Development settings
-│   │   ├── staging.py            # Staging settings
-│   │   └── prod.py               # Production settings
-│   ├── celery.py                 # Celery configuration
-│   └── urls.py                   # Root URL configuration
-├── data/                         # CSV seed files for management commands
-├── docs/                         # Documentation
-├── monitoring/                   # Monitoring configuration (Prometheus, Promtail)
-├── nginx/                        # Nginx configuration
-├── scripts/                      # Server setup and utility scripts
-├── static/                       # Project-wide static files
-├── templates/                    # HTML templates
-├── docker-compose.yml            # Docker Compose service definitions
-├── Dockerfile.dev                # Docker image for development
-├── Dockerfile.prod               # Docker image for production
-├── makefile                      # Custom project commands
-└── pyproject.toml                # Python project configuration
-```
+### Infrastructure & DevOps
+
+Three-environment architecture (dev / staging / prod) fully containerized with Docker. 30+ command Makefile CLI for setup, migrations, backups, log inspection, and container management — with production guards preventing destructive commands on live servers.
+
+CI/CD via self-hosted GitHub Actions runners with pull request checks, linting, build validation, and security scanning. Cache invalidation at both the application and CDN layers on every deployment.
+
+### Observability
+
+Sentry for real-time error tracking with full stack traces across environments. Grafana, Prometheus, and Loki for metrics and log aggregation. Automated daily PostgreSQL backups with tiered retention.
 
 ---
 
-## Getting Started
+## What I Learned
 
-### Prerequisites
-
-- **Docker Desktop** ([docker.com](https://www.docker.com/products/docker-desktop/))
-- **uv** (Python package manager)
-- **Ansible** — for server provisioning
-
-### Installation
-
-Clone the repository and configure your environment:
-
-```bash
-git clone https://github.com/PMC-BIT/l2c-portal.git
-cd l2c-portal
-cp .env.example .env
-```
-
-Key environment variables:
-
-| Variable | Description |
-|---|---|
-| `ENVIRONMENT` | `dev`, `staging`, or `prod` |
-| `POSTGRES_DB` | PostgreSQL database name |
-| `POSTGRES_USER` | PostgreSQL username |
-| `POSTGRES_PASSWORD` | PostgreSQL password |
-| `SECRET_KEY` | Django secret key |
-| `DEBUG` | `True` for development, `False` for production |
-| `ALLOWED_HOSTS` | Comma-separated allowed hostnames |
-| `REDIS_URL` | Redis connection URL |
-
-The project uses two SMTP accounts to avoid hitting daily sending limits — Gmail for low-priority emails and GoDaddy for high-priority (OTP, welcome, password reset).
-
-### Setup
-
-```bash
-make setup-dev
-```
-
-This creates containers, applies migrations, and creates a superuser. For normal startups afterward, use `make start`.
-
-### Server Provisioning
-
-Add the server IP to `ansible/inventory.ini` and run:
-
-```bash
-ansible-playbook -i ansible/inventory.ini ansible/playbooks/setup-server.yml --limit production --ask-pass --ask-become-pass
-```
+End-to-end ownership of a production system — database design, API architecture, server provisioning, CI/CD, and monitoring. Working without a senior on the infrastructure side required independent research, cross-referencing multiple sources, and deliberate architectural decisions.
 
 ---
 
-## Development Notes
+## Technologies
 
-### Environment Differences
-
-| Setting | Dev | Staging | Prod |
-|---|---|---|---|
-| `DEBUG` | `True` | `True` | `False` |
-| `SSL/HTTPS` | Disabled | Disabled | Configurable |
-| `CSP` | Report-only | Enforced | Enforced |
-| `LOG_LEVEL` | `DEBUG` | `INFO` | `WARNING` |
-
-### Monitoring
-
-| Service | URL | Purpose |
-|---|---|---|
-| Grafana | `http://localhost:3000` | Metrics dashboards |
-| Prometheus | `http://localhost:9090` | Raw metrics |
-| Loki | `http://localhost:3100` | Log aggregation |
-
-### Sentry
-
-Set `SENTRY_DSN` in `.env` to enable error tracking. Errors are tagged by environment — check the correct filter in the Sentry dashboard.
+**Backend:** Django, Django Ninja, Celery, PostgreSQL, Redis  
+**Infrastructure:** Docker, Nginx, Gunicorn, Ansible  
+**CI/CD:** GitHub Actions (self-hosted runners)  
+**Observability:** Sentry, Grafana, Prometheus, Loki  
+**Security:** 2FA, RBAC, rate limiting, Dependabot, CodeQL  
+**Documentation:** Post-mortems, runbooks, Ansible Vault for secrets

--- a/src/content/projects/vap-site.md
+++ b/src/content/projects/vap-site.md
@@ -1,0 +1,30 @@
+## Overview
+
+Client website for a Virtual Assistant provider — built as a freelance project. Static marketing site deployed on AWS with a serverless contact form.
+
+---
+
+## My Contribution
+
+Full ownership from development through infrastructure and CI/CD.
+
+### Application
+
+Next.js 16 static site with Tailwind CSS v4. Contact form handled via Lambda with SES for email delivery. Pages for services, about, and contact with a Cal.com booking integration.
+
+### Infrastructure
+
+Infrastructure as Code with Terraform — S3 for hosting, CloudFront with HTTPS via ACM, and a Lambda function URL for the contact form endpoint. DNS managed through Cloudflare with budget alerts configured.
+
+### CI/CD
+
+GitHub Actions with pull request validation (lint, build check) and automated deployments. On merge to main, the pipeline builds the static export, syncs to S3, and invalidates cache at both CloudFront and Cloudflare.
+
+---
+
+## Technologies
+
+**Application:** Next.js 16, TypeScript, Tailwind CSS v4  
+**Infrastructure:** AWS (S3, CloudFront, Lambda, SES, ACM), Terraform  
+**CI/CD:** GitHub Actions  
+**DNS:** Cloudflare

--- a/src/content/projects/vap-site.md
+++ b/src/content/projects/vap-site.md
@@ -2,8 +2,6 @@
 
 Client website for a Virtual Assistant provider — built as a freelance project. Static marketing site deployed on AWS with a serverless contact form.
 
----
-
 ## My Contribution
 
 Full ownership from development through infrastructure and CI/CD.
@@ -19,8 +17,6 @@ Infrastructure as Code with Terraform — S3 for hosting, CloudFront with HTTPS 
 ### CI/CD
 
 GitHub Actions with pull request validation (lint, build check) and automated deployments. On merge to main, the pipeline builds the static export, syncs to S3, and invalidates cache at both CloudFront and Cloudflare.
-
----
 
 ## Technologies
 

--- a/src/lib/site.ts
+++ b/src/lib/site.ts
@@ -260,7 +260,7 @@ export const projects: Project[] = [
     url: "https://rsoconnect.powermaccenter.com",
     repo: null,
     cover: "/projects/l2c-portal/cover.webp",
-    page: false,
+    page: true,
   },
   {
     title: "PMC Business",

--- a/src/lib/site.ts
+++ b/src/lib/site.ts
@@ -220,7 +220,7 @@ export const projects: Project[] = [
     title: "Digital Portfolio",
     slug: "digital-portfolio",
     pinned: true,
-    page: true,
+    page: false,
     description: "The website where you're currently reading this right now.",
     tags: ["AWS", "Terraform", "Cloudflare", "Next.js", "Tailwind CSS"],
     url: "https://luisabhram.dev",
@@ -236,7 +236,7 @@ export const projects: Project[] = [
     tags: ["AWS", "Terraform", "Cloudflare", "Next.js", "Tailwind CSS"],
     url: "https://jennyannvalenciano.com",
     cover: "/projects/vap-site/cover.webp",
-    page: true,
+    page: false,
   },
   {
     title: "Mobile Care PH",
@@ -260,7 +260,7 @@ export const projects: Project[] = [
     url: "https://rsoconnect.powermaccenter.com",
     repo: null,
     cover: "/projects/l2c-portal/cover.webp",
-    page: true,
+    page: false,
   },
   {
     title: "PMC Business",

--- a/src/lib/site.ts
+++ b/src/lib/site.ts
@@ -191,7 +191,7 @@ export const techStack = [
     ],
   },
   { category: "Cloud", items: ["AWS", "Cloudflare"] },
-  { category: "CI/CD", items: ["Git", "GitHub Actions"] },
+  { category: "CI/CD", items: ["Git", "GitHub Actions", "GitLab CI"] },
   { category: "Scripting", items: ["Python", "Bash", "Makefile"] },
   {
     category: "Monitoring",
@@ -220,12 +220,12 @@ export const projects: Project[] = [
     title: "Digital Portfolio",
     slug: "digital-portfolio",
     pinned: true,
+    page: true,
     description: "The website where you're currently reading this right now.",
     tags: ["Next.js", "AWS", "Terraform", "Cloudflare"],
     url: "https://luisabhram.dev",
     repo: "https://github.com/cymophic/portfolio",
     cover: "/projects/digital-portfolio/cover.webp",
-    page: false,
   },
   {
     title: "Jenny Ann VAP",

--- a/src/lib/site.ts
+++ b/src/lib/site.ts
@@ -236,7 +236,7 @@ export const projects: Project[] = [
     tags: ["AWS", "Terraform", "Cloudflare", "Next.js", "Tailwind CSS"],
     url: "https://jennyannvalenciano.com",
     cover: "/projects/vap-site/cover.webp",
-    page: false,
+    page: true,
   },
   {
     title: "Mobile Care PH",

--- a/src/lib/site.ts
+++ b/src/lib/site.ts
@@ -222,7 +222,7 @@ export const projects: Project[] = [
     pinned: true,
     page: true,
     description: "The website where you're currently reading this right now.",
-    tags: ["Next.js", "AWS", "Terraform", "Cloudflare"],
+    tags: ["AWS", "Terraform", "Cloudflare", "Next.js", "Tailwind CSS"],
     url: "https://luisabhram.dev",
     repo: "https://github.com/cymophic/portfolio",
     cover: "/projects/digital-portfolio/cover.webp",
@@ -233,7 +233,7 @@ export const projects: Project[] = [
     pinned: true,
     description:
       "Website migration of a Virtual Assistant Provider website from Wordpress to Next.js.",
-    tags: ["Next.js", "AWS", "Terraform", "Cloudflare"],
+    tags: ["AWS", "Terraform", "Cloudflare", "Next.js", "Tailwind CSS"],
     url: "https://jennyannvalenciano.com",
     cover: "/projects/vap-site/cover.webp",
     page: false,

--- a/terraform/locals.tf
+++ b/terraform/locals.tf
@@ -1,6 +1,6 @@
 locals {
   primary_domain = [var.domain_name, "www.${var.domain_name}"]
-  all_domains = distinct(flatten([local.primary_domain, var.other_domains]))
+  all_domains    = distinct(flatten([local.primary_domain, var.other_domains]))
   cors_origins = concat(
     [for domain in local.all_domains : "https://${domain}"],
     var.dev_origins


### PR DESCRIPTION
## What's Changed

### What's New

- **Project Detail Pages:** Add markdown-based project detail pages with an image pipeline, including a new page for the L2C Portal
- **Narrative Rewrites:** Rewrite the L2C Portal and VAP site project narratives
- **Coding Hours:** Show yearly WakaTime hours instead of monthly in the stats section

### Fixes & Upgrades

- **Breadcrumb:** Show "Home" in the breadcrumb on level-1 pages at all screen sizes
- **Code Blocks:** Use `clip-path` for rounded corners (Firefox fix)

### Refactors & Styling

- Reorder project tags and add Tailwind CSS
- Remove section dividers from L2C Portal and VAP site markdown
- Improve project detail page layout and markdown styling
- Format `terraform/locals.tf`

### Temporary

- Temporarily disable Digital Portfolio, VAP site, and L2C Portal project pages while their content is being reworked
