### PR TITLE
chore: store terraform state remotely in S3

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ luisabhram.dev/
 │   ├── eventbridge.tf                    # EventBridge scheduled triggers for Lambda
 │   ├── lambda.tf                         # Lambda functions and IAM roles
 │   ├── locals.tf                         # Centralized logic and data transformation layer
-│   ├── main.tf                           # Terraform and provider configuration
+│   ├── main.tf                           # Terraform, providers, and S3 backend config
 │   ├── outputs.tf                        # Terraform output values
 │   ├── s3.tf                             # S3 bucket, policy, and access configuration
 │   ├── variables.tf                      # Input definitions
@@ -197,6 +197,10 @@ spotify_refresh_token = ""
 # Monkeytype
 monkeytype_api_key = ""
 ```
+
+### Remote State
+
+Terraform state is stored remotely in S3 and configured in `terraform/main.tf` — no extra setup needed. Just run `terraform init`.
 
 ### Provision AWS Resources
 

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -4,6 +4,16 @@ terraform {
       source  = "hashicorp/aws"
       version = "~> 5.0"
     }
+    archive = {
+      source  = "hashicorp/archive"
+      version = "~> 2.7"
+    }
+  }
+
+  backend "s3" {
+    bucket = "cymo-tfstate-storage"
+    key    = "portfolio/terraform.tfstate"
+    region = "ap-southeast-1"
   }
 }
 


### PR DESCRIPTION
## What's Changed
- Move Terraform state to remote S3 (`cymo-tfstate-storage`) with the backend hardcoded in `terraform/main.tf`
- Document the new Remote State setup in the README (just `terraform init`, no extra setup)

Applies only if there are changes. Verified locally: `terraform plan` reports no changes after migration.
