### PR TITLE
fix: make lambda hashes deterministic and fix deploy-infra change detection

### DIFF
--- a/.github/workflows/check-pr.yml
+++ b/.github/workflows/check-pr.yml
@@ -70,7 +70,7 @@ jobs:
         if: steps.changes.outputs.infra == 'true'
         uses: hashicorp/setup-terraform@v3
         with:
-          terraform_version: "1.14"
+          terraform_version: "1.15.8"
 
       - name: Configure AWS credentials
         if: steps.changes.outputs.infra == 'true'

--- a/.github/workflows/deploy-infra.yml
+++ b/.github/workflows/deploy-infra.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@v3
         with:
-          terraform_version: "1.14"
+          terraform_version: "1.15.8"
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v6
@@ -37,15 +37,10 @@ jobs:
       - name: Terraform plan and apply
         working-directory: terraform
         run: |
-          set +e
-          terraform plan -input=false -no-color -detailed-exitcode -out=tfplan -var-file="$RUNNER_TEMP/terraform.tfvars"
-          plan_exit=$?
-          set -e
-          if [ "$plan_exit" -eq 1 ]; then
-            exit 1
-          fi
-          if [ "$plan_exit" -eq 2 ]; then
-            echo "Infrastructure changes detected - applying."
+          terraform plan -input=false -no-color -out=tfplan -var-file="$RUNNER_TEMP/terraform.tfvars"
+          changes=$(terraform show -json tfplan | jq '[.resource_changes[] | select(.change.actions | any(. != "no-op"))] | length')
+          if [ "$changes" -gt 0 ]; then
+            echo "Infrastructure changes detected ($changes) - applying."
             terraform apply -input=false -no-color -auto-approve tfplan
           else
             echo "No infrastructure changes - skipping apply."

--- a/terraform/lambda.tf
+++ b/terraform/lambda.tf
@@ -66,7 +66,7 @@ resource "aws_lambda_function" "github" {
   role             = aws_iam_role.lambda_shared.arn
   handler          = "github.handler"
   runtime          = "nodejs22.x"
-  source_code_hash = data.archive_file.github.output_base64sha256
+  source_code_hash = filebase64sha256(data.archive_file.github.source_file)
   timeout          = 10
 
   environment {
@@ -97,7 +97,7 @@ resource "aws_lambda_function" "wakatime" {
   role             = aws_iam_role.lambda_shared.arn
   handler          = "wakatime.handler"
   runtime          = "nodejs22.x"
-  source_code_hash = data.archive_file.wakatime.output_base64sha256
+  source_code_hash = filebase64sha256(data.archive_file.wakatime.source_file)
   timeout          = 10
 
   environment {
@@ -127,7 +127,7 @@ resource "aws_lambda_function" "monkeytype" {
   role             = aws_iam_role.lambda_shared.arn
   handler          = "monkeytype.handler"
   runtime          = "nodejs22.x"
-  source_code_hash = data.archive_file.monkeytype.output_base64sha256
+  source_code_hash = filebase64sha256(data.archive_file.monkeytype.source_file)
   timeout          = 10
 
   environment {
@@ -157,7 +157,7 @@ resource "aws_lambda_function" "spotify_now_playing" {
   role             = aws_iam_role.lambda_shared.arn
   handler          = "now-playing.handler"
   runtime          = "nodejs22.x"
-  source_code_hash = data.archive_file.spotify_now_playing.output_base64sha256
+  source_code_hash = filebase64sha256(data.archive_file.spotify_now_playing.source_file)
   timeout          = 15
 
   environment {
@@ -202,7 +202,7 @@ resource "aws_lambda_function" "spotify_stats" {
   role             = aws_iam_role.lambda_shared.arn
   handler          = "stats.handler"
   runtime          = "nodejs22.x"
-  source_code_hash = data.archive_file.spotify_stats.output_base64sha256
+  source_code_hash = filebase64sha256(data.archive_file.spotify_stats.source_file)
   timeout          = 15
 
   environment {


### PR DESCRIPTION
## What's Changed

- Fix deploy-infra detecting "no changes" despite a non-empty plan: replace `-detailed-exitcode` with robust change counting via `terraform show -json` + `jq`, and pin terraform to `1.15.8` (matches local)
- Fix perpetual lambda drift: `source_code_hash` now hashes the lambda source file content (`filebase64sha256`) instead of the zip output, which was non-deterministic across CI/local environments
- Bump terraform version in check-pr to `1.15.8` for consistency

Note: the first run after this merges will update all 5 lambdas once (same code, new hash format); after that, plans are stable.
