### PR TITLE
ci: fix check-pr issues (codeql push hook, node 24 actions, unused imports)

### DIFF
--- a/.github/workflows/check-pr.yml
+++ b/.github/workflows/check-pr.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     branches:
       - main
+  push:
+    branches:
+      - main
 
 jobs:
   lint:
@@ -58,7 +61,7 @@ jobs:
 
       - name: Detect infrastructure changes
         id: changes
-        uses: dorny/paths-filter@v3
+        uses: dorny/paths-filter@v4
         with:
           filters: |
             infra:
@@ -68,7 +71,7 @@ jobs:
 
       - name: Setup Terraform
         if: steps.changes.outputs.infra == 'true'
-        uses: hashicorp/setup-terraform@v3
+        uses: hashicorp/setup-terraform@v4
         with:
           terraform_version: "1.15.8"
 

--- a/.github/workflows/deploy-infra.yml
+++ b/.github/workflows/deploy-infra.yml
@@ -16,7 +16,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup Terraform
-        uses: hashicorp/setup-terraform@v3
+        uses: hashicorp/setup-terraform@v4
         with:
           terraform_version: "1.15.8"
 

--- a/src/app/(main)/projects/[slug]/page.tsx
+++ b/src/app/(main)/projects/[slug]/page.tsx
@@ -12,9 +12,7 @@ import Pill from "@/components/ui/Pill";
 import {
   IconExternalLink,
   IconCodeblock,
-  IconArrowLeft,
 } from "@tabler/icons-react";
-import Link from "next/link";
 
 export async function generateMetadata({
   params,


### PR DESCRIPTION
﻿## Summary
- Add `on.push` (branches: main) to check-pr.yml so CodeQL analyzes default-branch pushes (resolves the "specify an on.push hook" warning).
- Bump `dorny/paths-filter` v3 -> v4 and `hashicorp/setup-terraform` v3 -> v4 (both now run on Node 24, clearing the Node 20 deprecation warning).
- Remove unused `Link` / `IconArrowLeft` imports in `src/app/(main)/projects/[slug]/page.tsx` (lint fix).

These were the remaining check-pr failures from PR #180, which merged before this commit was pushed to dev.
