### PR TITLE
ci: polish workflows (check-pr fan-out, deploy filters, concurrency)

### DIFF
--- a/.github/workflows/check-pr.yml
+++ b/.github/workflows/check-pr.yml
@@ -11,6 +11,9 @@ on:
 jobs:
   changes:
     runs-on: ubuntu-latest
+    outputs:
+      js: ${{ steps.filter.outputs.js }}
+      infra: ${{ steps.filter.outputs.infra }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v6

--- a/.github/workflows/check-pr.yml
+++ b/.github/workflows/check-pr.yml
@@ -9,7 +9,34 @@ on:
       - main
 
 jobs:
+  changes:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Detect changed paths
+        id: filter
+        uses: dorny/paths-filter@v4
+        with:
+          filters: |
+            js:
+              - 'src/**'
+              - 'lambda/**'
+              - 'scripts/**'
+              - '**/*.ts'
+              - '**/*.mjs'
+              - '**/*.js'
+            infra:
+              - 'terraform/**'
+              - 'lambda/**'
+              - '.github/workflows/check-pr.yml'
+
   lint:
+    needs: changes
+    if: needs.changes.outputs.js == 'true'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -28,6 +55,8 @@ jobs:
         run: npm run lint
 
   build:
+    needs: changes
+    if: needs.changes.outputs.js == 'true'
     uses: ./.github/workflows/build-app.yml
     with:
       NEXT_PUBLIC_SITE_MODE: ${{ vars.NEXT_PUBLIC_SITE_MODE }}
@@ -35,6 +64,8 @@ jobs:
       NEXT_PUBLIC_CDN_URL: ${{ vars.NEXT_PUBLIC_CDN_URL }}
 
   codeql:
+    needs: changes
+    if: needs.changes.outputs.js == 'true'
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -43,30 +74,17 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v6
 
-      - name: Detect JavaScript changes
-        id: changes
-        uses: dorny/paths-filter@v4
-        with:
-          filters: |
-            js:
-              - 'src/**'
-              - 'lambda/**'
-              - 'scripts/**'
-              - '**/*.ts'
-              - '**/*.mjs'
-              - '**/*.js'
-
       - name: Initialize CodeQL
-        if: steps.changes.outputs.js == 'true'
         uses: github/codeql-action/init@v4
         with:
           languages: javascript
 
       - name: Perform CodeQL Analysis
-        if: steps.changes.outputs.js == 'true'
         uses: github/codeql-action/analyze@v4
 
   terraform:
+    needs: changes
+    if: needs.changes.outputs.infra == 'true'
     runs-on: ubuntu-latest
     env:
       TF_VAR_github_pat: ${{ secrets.GH_PAT }}
@@ -81,24 +99,12 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Detect infrastructure changes
-        id: changes
-        uses: dorny/paths-filter@v4
-        with:
-          filters: |
-            infra:
-              - 'terraform/**'
-              - 'lambda/**'
-              - '.github/workflows/check-pr.yml'
-
       - name: Setup Terraform
-        if: steps.changes.outputs.infra == 'true'
         uses: hashicorp/setup-terraform@v4
         with:
           terraform_version: "1.15.8"
 
       - name: Configure AWS credentials
-        if: steps.changes.outputs.infra == 'true'
         uses: aws-actions/configure-aws-credentials@v6
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
@@ -106,22 +112,18 @@ jobs:
           aws-region: ap-southeast-1
 
       - name: Terraform init
-        if: steps.changes.outputs.infra == 'true'
         working-directory: terraform
         run: terraform init -input=false -no-color
 
       - name: Terraform format
-        if: steps.changes.outputs.infra == 'true'
         working-directory: terraform
         run: terraform fmt -check -recursive
 
       - name: Terraform validate
-        if: steps.changes.outputs.infra == 'true'
         working-directory: terraform
         run: terraform validate -no-color
 
       - name: Terraform plan
-        if: steps.changes.outputs.infra == 'true'
         working-directory: terraform
         run: |
           set +e

--- a/.github/workflows/deploy-infra.yml
+++ b/.github/workflows/deploy-infra.yml
@@ -8,6 +8,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: infra-deploy
+  cancel-in-progress: false
+
 jobs:
   deploy:
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy-infra.yml
+++ b/.github/workflows/deploy-infra.yml
@@ -9,7 +9,7 @@ permissions:
   contents: read
 
 concurrency:
-  group: infra-deploy
+  group: deploy-infra
   cancel-in-progress: false
 
 jobs:

--- a/.github/workflows/deploy-site.yml
+++ b/.github/workflows/deploy-site.yml
@@ -20,7 +20,7 @@ permissions:
   contents: read
 
 concurrency:
-  group: site-deploy
+  group: deploy-site
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/deploy-site.yml
+++ b/.github/workflows/deploy-site.yml
@@ -49,12 +49,31 @@ jobs:
           aws-region: ap-southeast-1
 
       - name: Deploy to S3
-        run: aws s3 sync out/ s3://${{ secrets.S3_BUCKET_NAME }} --delete --exclude "stats/*"
+        id: sync
+        run: |
+          set +e
+          output=$(aws s3 sync out/ s3://${{ secrets.S3_BUCKET_NAME }} --delete --exclude "stats/*")
+          sync_exit=$?
+          set -e
+          if [ "$sync_exit" -ne 0 ]; then
+            echo "$output"
+            exit "$sync_exit"
+          fi
+          changed=$(echo "$output" | grep -c "upload:\|delete:" || true)
+          if [ "$changed" -gt 0 ]; then
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+            echo "Uploaded/removed $changed file(s)."
+          else
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            echo "No site changes - skipping cache invalidation."
+          fi
 
       - name: Invalidate CloudFront cache
+        if: steps.sync.outputs.changed == 'true'
         run: aws cloudfront create-invalidation --distribution-id ${{ secrets.CLOUDFRONT_DISTRIBUTION_ID }} --paths "/*"
 
       - name: Purge Cloudflare cache
+        if: steps.sync.outputs.changed == 'true'
         uses: jakejarvis/cloudflare-purge-action@eee6dba0236093358f25bb1581bd615dc8b3d8e3
         env:
           CLOUDFLARE_ZONE: ${{ secrets.CLOUDFLARE_ZONE_ID }}

--- a/.github/workflows/deploy-site.yml
+++ b/.github/workflows/deploy-site.yml
@@ -4,6 +4,24 @@ on:
   push:
     branches:
       - main
+    paths:
+      - "src/**"
+      - "scripts/**"
+      - "package.json"
+      - "package-lock.json"
+      - "next.config.ts"
+      - "tsconfig.json"
+      - "postcss.config.mjs"
+      - "eslint.config.mjs"
+      - ".github/workflows/deploy-site.yml"
+      - ".github/workflows/build-app.yml"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: site-deploy
+  cancel-in-progress: true
 
 jobs:
   build:
@@ -37,7 +55,7 @@ jobs:
         run: aws cloudfront create-invalidation --distribution-id ${{ secrets.CLOUDFRONT_DISTRIBUTION_ID }} --paths "/*"
 
       - name: Purge Cloudflare cache
-        uses: jakejarvis/cloudflare-purge-action@master
+        uses: jakejarvis/cloudflare-purge-action@eee6dba0236093358f25bb1581bd615dc8b3d8e3
         env:
           CLOUDFLARE_ZONE: ${{ secrets.CLOUDFLARE_ZONE_ID }}
           CLOUDFLARE_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}


### PR DESCRIPTION
## What
Polish the CI workflows for correctness, cost, and safety:

- **check-pr**: fan out `lint`/`build`/`codeql`/`terraform` behind a shared `changes` job (single `dorny/paths-filter`), so each job skips when its paths are untouched and the graph shows a connected fan-out.
- **deploy-site**: add a site-relevant `paths` filter (no more full rebuilds on infra-only pushes), `permissions`, `concurrency` (newest push wins), pin the Cloudflare purge action to a commit SHA, and skip CloudFront/Cloudflare invalidations when the deploy uploads nothing (saves CloudFront invalidation costs).
- **deploy-infra**: serialize terraform applies with `concurrency` (queued, not cancelled, since the S3 backend has no state locking).
- Rename concurrency groups to match workflow names.

## Notes
- `terraform plan` semantics unchanged; local-only secrets flow untouched.
- Cloudflare purge action pinned to `eee6dba` (matches previous `@master` behavior, locked to reviewed code).
