### PR TITLE
ci: harden workflows, reduce S3 costs, cache hashed assets

### DIFF
--- a/.github/workflows/deploy-site.yml
+++ b/.github/workflows/deploy-site.yml
@@ -63,6 +63,13 @@ jobs:
           if [ "$changed" -gt 0 ]; then
             echo "changed=true" >> "$GITHUB_OUTPUT"
             echo "Uploaded/removed $changed file(s)."
+            paths=$(echo "$output" | grep "upload:\|delete:" | sed -E \
+              -e 's/^upload: .* to s3:\/\/[^/]+\///' \
+              -e 's/^delete: s3:\/\/[^/]+\///' \
+              | sed 's#^#/#')
+            echo "paths<<EOF" >> "$GITHUB_OUTPUT"
+            echo "$paths" >> "$GITHUB_OUTPUT"
+            echo "EOF" >> "$GITHUB_OUTPUT"
           else
             echo "changed=false" >> "$GITHUB_OUTPUT"
             echo "No site changes - skipping cache invalidation."
@@ -70,7 +77,17 @@ jobs:
 
       - name: Invalidate CloudFront cache
         if: steps.sync.outputs.changed == 'true'
-        run: aws cloudfront create-invalidation --distribution-id ${{ secrets.CLOUDFRONT_DISTRIBUTION_ID }} --paths "/*"
+        run: |
+          items=()
+          while IFS= read -r line; do
+            if [ -n "$line" ]; then
+              items+=("$line")
+            fi
+          done <<< "${{ steps.sync.outputs.paths }}"
+          if [ "${#items[@]}" -le 0 ] || [ "${#items[@]}" -gt 3000 ]; then
+            items=("/*")
+          fi
+          aws cloudfront create-invalidation --distribution-id ${{ secrets.CLOUDFRONT_DISTRIBUTION_ID }} --paths "${items[@]}"
 
       - name: Purge Cloudflare cache
         if: steps.sync.outputs.changed == 'true'

--- a/terraform/cloudfront.tf
+++ b/terraform/cloudfront.tf
@@ -37,6 +37,26 @@ resource "aws_cloudfront_distribution" "portfolio" {
     }
   }
 
+  ordered_cache_behavior {
+    path_pattern               = "_next/static/*"
+    allowed_methods            = ["GET", "HEAD"]
+    cached_methods             = ["GET", "HEAD"]
+    target_origin_id           = "S3-${var.bucket_name}"
+    viewer_protocol_policy     = "redirect-to-https"
+    response_headers_policy_id = aws_cloudfront_response_headers_policy.cors.id
+
+    forwarded_values {
+      query_string = false
+      cookies {
+        forward = "none"
+      }
+    }
+
+    min_ttl     = 31536000
+    default_ttl = 31536000
+    max_ttl     = 31536000
+  }
+
   custom_error_response {
     error_code            = 403
     response_code         = 404


### PR DESCRIPTION
## Summary

Brings the accumulated CI/infra work on `dev` to `main`.

### Workflows
- Fan out `check-pr` jobs via a shared `paths-filter` (`5e7aae8`)
- Harden `deploy-site` with paths filter, concurrency, permissions, pinned actions (`18d582b`)
- Skip cache invalidations when a deploy uploads nothing (`4daddcf`)
- Serialize terraform applies via a shared concurrency group (`d1b345a`)
- Name concurrency groups after their workflows (`60e2528`)
- Expose `changes` job outputs in `check-pr` (`742059e`)
- Invalidate only changed paths on site deploy instead of `/*` (`836f1fa`)

### Infra (S3/CloudFront costs)
- Cache hashed `_next/static/*` assets for a year via an ordered cache behavior (`abb7ed7`)

## Behavior
- Cache invalidations now target only the changed files; unchanged hashed assets stay cached at the edge (fewer S3 origin GETs).
- Hashed static assets get a 365-day TTL; HTML stays on the default 24h behavior.

## Verification
- `terraform fmt` + `terraform validate` pass.
- Invalidation path parsing verified against `aws s3 sync` output format.

## Notes
- `check-pr` now also runs on push to main - see review note about a possible S3 state-lock race with `deploy-infra` on merge.
