### PR TITLE
ci: fix invalid cache invalidation paths

### DIFF
--- a/.github/workflows/deploy-site.yml
+++ b/.github/workflows/deploy-site.yml
@@ -66,7 +66,9 @@ jobs:
             paths=$(echo "$output" | grep "upload:\|delete:" | sed -E \
               -e 's/^upload: .* to s3:\/\/[^/]+\///' \
               -e 's/^delete: s3:\/\/[^/]+\///' \
-              | sed 's#^#/#')
+              | sed 's#^#/#' \
+              | grep -v '^/_next/static/' \
+              | grep '^/[A-Za-z0-9._/-]*$' || true)
             echo "paths<<EOF" >> "$GITHUB_OUTPUT"
             echo "$paths" >> "$GITHUB_OUTPUT"
             echo "EOF" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
Fixes the Deploy Site Changes failure (InvalidArgument / exit 254) from the narrow CloudFront invalidation introduced in #185.

Next.js S3 keys contain characters CloudFront rejects in invalidation paths (e.g. \!\, \$\, \~\ in \_next/static\ chunks and media). This filters extracted paths to CloudFront-safe characters and skips immutable \_next/static/*\ hashed assets, which never need invalidation.