### PR TITLE
infra: add default tags to AWS provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ The site is live at [luisabhram.dev](https://luisabhram.dev)
 - **Framework:** Next.js 16
 - **Language:** TypeScript
 - **Styling:** Tailwind CSS v4
-- **Animations:** GSAP, Motion
+- **Animations:** GSAP
 
 ### Infrastructure
 - **Frontend Hosting:** AWS S3 & AWS CloudFront

--- a/src/components/sections/home/Stats/ContributionGraph.tsx
+++ b/src/components/sections/home/Stats/ContributionGraph.tsx
@@ -202,8 +202,8 @@ export default function ContributionGraph({
       <div className="px-1 flex items-center justify-between gap-x-8 text-xs text-zinc-500 dark:text-zinc-400">
         {/* Contribution Count */}
         <span className="truncate">
-          {totalContributions?.toLocaleString() ?? 0} GitHub contributions in
-          the last year
+          {totalContributions?.toLocaleString() ?? 0} contributions in the
+          last year
         </span>
 
         {/* Legend */}

--- a/terraform/acm.tf
+++ b/terraform/acm.tf
@@ -5,10 +5,6 @@ resource "aws_acm_certificate" "portfolio" {
 
   subject_alternative_names = [for domain in local.all_domains : domain if domain != var.domain_name]
 
-  tags = {
-    Project = var.project_name
-  }
-
   lifecycle {
     create_before_destroy = true
   }

--- a/terraform/cloudfront.tf
+++ b/terraform/cloudfront.tf
@@ -82,10 +82,6 @@ resource "aws_cloudfront_distribution" "portfolio" {
     ssl_support_method       = "sni-only"
     minimum_protocol_version = "TLSv1.2_2021"
   }
-
-  tags = {
-    Project = var.project_name
-  }
 }
 
 resource "aws_cloudfront_function" "rewrite_uri" {

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -20,8 +20,22 @@ terraform {
 provider "aws" {
   alias  = "us_east_1"
   region = "us-east-1"
+
+  default_tags {
+    tags = {
+      Project   = var.project_name
+      ManagedBy = "terraform"
+    }
+  }
 }
 
 provider "aws" {
   region = var.aws_region
+
+  default_tags {
+    tags = {
+      Project   = var.project_name
+      ManagedBy = "terraform"
+    }
+  }
 }

--- a/terraform/s3.tf
+++ b/terraform/s3.tf
@@ -1,9 +1,5 @@
 resource "aws_s3_bucket" "portfolio" {
   bucket = var.bucket_name
-
-  tags = {
-    Project = var.project_name
-  }
 }
 
 resource "aws_s3_bucket_website_configuration" "portfolio" {


### PR DESCRIPTION
Adds provider-level `default_tags` (`Project`, `ManagedBy: terraform`) to both AWS provider blocks so all resources are tagged automatically, and removes the now-redundant per-resource `tags` blocks.

Also includes two earlier unreleased commits: contribution-graph label made platform-agnostic, and GSAP removed from the README tech stack.
